### PR TITLE
Make the custom logger the default for Hazelcast

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -77,10 +77,7 @@ func createNewHazelcastConfig() hazelcast.Config {
 
 	cacheConfig.Cluster.Name = config.Current.Hazelcast.ClusterName
 	cacheConfig.Cluster.Network.SetAddresses(config.Current.Hazelcast.ServiceDNS)
-
-	if config.Current.Hazelcast.CustomLoggerEnabled {
-		cacheConfig.Logger.CustomLogger = new(util.HazelcastZerologLogger)
-	}
+	cacheConfig.Logger.CustomLogger = new(util.HazelcastZerologLogger)
 
 	return cacheConfig
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,7 +63,6 @@ func setDefaults() {
 	// Hazelcast
 	viper.SetDefault("hazelcast.clusterName", "dev")
 	viper.SetDefault("hazelcast.serviceDNS", "localhost:5701")
-	viper.SetDefault("hazelcast.customLoggerEnabled", false)
 
 	// Kafka
 	viper.SetDefault("kafka.brokers", "localhost:9092")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -26,8 +26,8 @@ type Configuration struct {
 type CircuitBreaker struct {
 	OpenCheckInterval       time.Duration `mapstructure:"openCheckInterval"`
 	OpenLoopDetectionPeriod time.Duration `mapstructure:"openLoopDetectionPeriod"`
-	ExponentialBackoffBase    time.Duration `mapstructure:"exponentialBackoffBase"`
-	ExponentialBackoffMax     time.Duration `mapstructure:"exponentialBackoffMax"`
+	ExponentialBackoffBase  time.Duration `mapstructure:"exponentialBackoffBase"`
+	ExponentialBackoffMax   time.Duration `mapstructure:"exponentialBackoffMax"`
 }
 
 type HealthCheck struct {
@@ -43,10 +43,9 @@ type Republishing struct {
 }
 
 type Hazelcast struct {
-	ServiceDNS          string `mapstructure:"serviceDNS"`
-	ClusterName         string `mapstructure:"clusterName"`
-	Caches              Caches `mapstructure:"caches"`
-	CustomLoggerEnabled bool   `mapstructure:"customLoggerEnabled"`
+	ServiceDNS  string `mapstructure:"serviceDNS"`
+	ClusterName string `mapstructure:"clusterName"`
+	Caches      Caches `mapstructure:"caches"`
 }
 
 type Caches struct {

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -36,7 +36,6 @@ func BuildTestConfig() config.Configuration {
 				HealthCheckCache:    "hcCache",
 				RepublishingCache:   "repCache",
 			},
-			CustomLoggerEnabled: false,
 		},
 		Kafka: config.Kafka{
 			Brokers: []string{"broker1:9092", "broker2:9092"},


### PR DESCRIPTION
This removes the obsolete switch for using the custom zerolog-based logger.