### PR TITLE
Set lastOpened in loop detection

### DIFF
--- a/internal/circuitbreaker/circuitbreaker.go
+++ b/internal/circuitbreaker/circuitbreaker.go
@@ -130,6 +130,8 @@ func checkForCircuitBreakerLoop(cbMessage *message.CircuitBreakerMessage) error 
 		cbMessage.LoopCounter = 0
 		log.Debug().Msgf("Circuit breaker opened outside loop detection period. Reseted loop counter for subscription %s: %v", cbMessage.SubscriptionId, cbMessage.LoopCounter)
 	}
+	// set last opened for the next loop detection
+	cbMessage.LastOpened = cbMessage.LastModified
 	cbMessage.LastModified = types.NewTimestamp(time.Now().UTC())
 
 	err := cache.CircuitBreakerCache.Put(config.Current.Hazelcast.Caches.CircuitBreakerCache, cbMessage.SubscriptionId, *cbMessage)


### PR DESCRIPTION
This pr fixes the timestamp lastOpened in the circuit-breaker message