### PR TITLE
Fix for health check handling in case of client timeouts

### DIFF
--- a/internal/kafka/picker.go
+++ b/internal/kafka/picker.go
@@ -13,7 +13,6 @@ import (
 
 type Picker struct {
 	consumer sarama.Consumer
-	sarama.KError
 }
 
 type MessagePicker interface {


### PR DESCRIPTION
This pr contains the following small changes concerning the check error handling
- Increased lock lease time for health check cache in order not to release the lock too early in case of client timeouts
- Update health check cache state in case of  client timeouts
- Log client timeouts with level info instead of error 