### PR TITLE
feat(hazelcast): use custom Hazelcsast client id

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -7,6 +7,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"github.com/rs/zerolog"
@@ -15,6 +16,7 @@ import (
 	"github.com/telekom/pubsub-horizon-go/message"
 	"github.com/telekom/pubsub-horizon-go/resource"
 	"github.com/telekom/pubsub-horizon-go/util"
+	"os"
 	"pubsub-horizon-golaris/internal/config"
 	"sync"
 	"time"
@@ -78,9 +80,14 @@ func Initialize() {
 func createNewHazelcastConfig() hazelcast.Config {
 	cacheConfig := hazelcast.NewConfig()
 
+	instanceName := os.Getenv("POD_NAME")
+	if instanceName == "" {
+		instanceName = "golaris-" + uuid.New().String()
+	}
 	cacheConfig.Cluster.Name = config.Current.Hazelcast.ClusterName
 	cacheConfig.Cluster.Network.SetAddresses(config.Current.Hazelcast.ServiceDNS)
 	cacheConfig.Logger.CustomLogger = util.NewHazelcastZerologLogger(parseHazelcastLogLevel(config.Current.Hazelcast.LogLevel))
+	cacheConfig.ClientName = instanceName
 
 	return cacheConfig
 }

--- a/internal/handler/delivering.go
+++ b/internal/handler/delivering.go
@@ -20,7 +20,7 @@ func CheckDeliveringEvents() {
 
 	var ctx = cache.HandlerCache.NewLockContext(context.Background())
 
-	if acquired, _ := cache.HandlerCache.TryLockWithTimeout(ctx, cache.DeliveringLockKey, 10*time.Millisecond); !acquired {
+	if acquired, _ := cache.HandlerCache.TryLockWithTimeout(ctx, cache.DeliveringLockKey, 100*time.Millisecond); !acquired {
 		log.Debug().Msgf("Could not acquire lock for DeliveringHandler entry: %s", cache.DeliveringLockKey)
 		return
 	}

--- a/internal/handler/failed.go
+++ b/internal/handler/failed.go
@@ -21,7 +21,7 @@ func CheckFailedEvents() {
 
 	var ctx = cache.HandlerCache.NewLockContext(context.Background())
 
-	if acquired, _ := cache.HandlerCache.TryLockWithTimeout(ctx, cache.FailedLockKey, 10*time.Millisecond); !acquired {
+	if acquired, _ := cache.HandlerCache.TryLockWithTimeout(ctx, cache.FailedLockKey, 100*time.Millisecond); !acquired {
 		log.Debug().Msgf("Could not acquire lock for FailedHandler entry: %s", cache.FailedLockKey)
 		return
 	}

--- a/internal/handler/waiting.go
+++ b/internal/handler/waiting.go
@@ -37,7 +37,7 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 	// Create a WaitingHandler entry and lock it
 	var ctx = cache.HandlerCache.NewLockContext(context.Background())
 
-	if acquired, _ := cache.HandlerCache.TryLockWithTimeout(ctx, cache.WaitingLockKey, 10*time.Millisecond); !acquired {
+	if acquired, _ := cache.HandlerCache.TryLockWithTimeout(ctx, cache.WaitingLockKey, 100*time.Millisecond); !acquired {
 		log.Debug().Msgf("WaitingHandler: Could not acquire lock for WaitingHandler entry: %s", cache.WaitingLockKey)
 		return
 	}

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -151,7 +151,7 @@ func PrepareHealthCheck(subscription *resource.SubscriptionResource) (*PreparedH
 
 	// Attempt to acquire a lock for the health check key
 	//isAcquired, _ := cache.HealthCheckCache.TryLockWithTimeout(ctx, healthCheckKey, 10*time.Millisecond)
-	isAcquired, _ := cache.HealthCheckCache.TryLockWithLeaseAndTimeout(ctx, healthCheckKey, 60000*time.Millisecond, 10*time.Millisecond)
+	isAcquired, _ := cache.HealthCheckCache.TryLockWithLeaseAndTimeout(ctx, healthCheckKey, 60000*time.Millisecond, 100*time.Millisecond)
 
 	castedHealthCheckEntry := healthCheckEntry.(HealthCheckCacheEntry)
 	return &PreparedHealthCheckData{Ctx: ctx, HealthCheckKey: healthCheckKey, HealthCheckEntry: castedHealthCheckEntry, IsAcquired: isAcquired}, nil

--- a/internal/republish/republish.go
+++ b/internal/republish/republish.go
@@ -72,7 +72,7 @@ func HandleRepublishingEntry(subscription *resource.SubscriptionResource) {
 	}
 
 	// Attempt to acquire a lock on the republishing entry
-	if acquired, _ = cache.RepublishingCache.TryLockWithTimeout(ctx, subscriptionId, 10*time.Millisecond); !acquired {
+	if acquired, _ = cache.RepublishingCache.TryLockWithTimeout(ctx, subscriptionId, 100*time.Millisecond); !acquired {
 		log.Debug().Msgf("Could not acquire lock for RepublishingCacheEntry, skipping entry for subscriptionId %s", subscriptionId)
 		return
 	}


### PR DESCRIPTION
This PR not only introduces the use of a custom Hazelcsast client id but also higher timeouts for acquiring locks within Hazelcsast.