### PR TITLE
fix(republishing): subscription-specific throttling

### DIFF
--- a/internal/republish/republish_test.go
+++ b/internal/republish/republish_test.go
@@ -248,7 +248,7 @@ func TestRepublishEventsThrottled(t *testing.T) {
 	config.Current.Republishing.BatchSize = int64(numDbMessages + 1)
 	config.Current.Republishing.ThrottlingIntervalTime = 1 * time.Second
 
-	dbMessages := test.GenerateMessages("test-topic", 1, 100, numDbMessages)
+	dbMessages := test.GenerateStatusMessages("test-topic", 1, 100, numDbMessages)
 
 	kafkaMessage := sarama.ConsumerMessage{Value: []byte("test-content")}
 
@@ -302,7 +302,7 @@ func TestRepublishEventsUnThrottled(t *testing.T) {
 	config.Current.Republishing.BatchSize = int64(numDbMessages + 1)
 	config.Current.Republishing.ThrottlingIntervalTime = 1 * time.Second
 
-	dbMessages := test.GenerateMessages("test-topic", 1, 100, numDbMessages)
+	dbMessages := test.GenerateStatusMessages("test-topic", 1, 100, numDbMessages)
 
 	kafkaMessage := sarama.ConsumerMessage{Value: []byte("test-content")}
 

--- a/internal/republish/republish_test.go
+++ b/internal/republish/republish_test.go
@@ -226,3 +226,111 @@ func Test_ForceDelete_RepublishingEntryUnlocked(t *testing.T) {
 	// Assertions
 	assertions.False(cache.RepublishingCache.ContainsKey(ctx, testSubscriptionId))
 }
+
+func TestRepublishEventsThrottled(t *testing.T) {
+	// Initialize mocks
+	mockMongo := new(test.MockMongoHandler)
+	mockKafka := new(test.MockKafkaHandler)
+
+	mockPicker := new(test.MockPicker)
+	test.InjectMockPicker(mockPicker)
+
+	// Replace real handlers with mocks
+	mongo.CurrentConnection = mockMongo
+	kafka.CurrentHandler = mockKafka
+
+	// Mock data
+	subscriptionId := "sub123"
+	numDbMessages := 50
+	redeliveriesPerSecond := 10
+
+	// Set configurations for the test
+	config.Current.Republishing.BatchSize = int64(numDbMessages + 1)
+	config.Current.Republishing.ThrottlingIntervalTime = 1 * time.Second
+
+	dbMessages := test.GenerateMessages("test-topic", 1, 100, numDbMessages)
+
+	kafkaMessage := sarama.ConsumerMessage{Value: []byte("test-content")}
+
+	// Expectations for the batch
+	mockMongo.On("FindWaitingMessages", mock.Anything, mock.Anything, subscriptionId).Return(dbMessages, nil, nil).Once()
+
+	mockPicker.On("Pick", mock.AnythingOfType("*message.StatusMessage")).Return(&kafkaMessage, nil).Times(len(dbMessages))
+	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").Return(nil).Times(len(dbMessages))
+
+	// Call the function under test
+	subscription := &resource.SubscriptionResource{
+		Spec: struct {
+			Subscription resource.Subscription `json:"subscription"`
+			Environment  string                `json:"environment"`
+		}{
+			Subscription: resource.Subscription{
+				SubscriptionId:        "sub123",
+				DeliveryType:          enum.DeliveryTypeCallback,
+				Callback:              "http://new-callbackUrl/callback",
+				RedeliveriesPerSecond: redeliveriesPerSecond,
+			},
+		},
+	}
+
+	RepublishPendingEvents(subscription, RepublishingCacheEntry{SubscriptionId: subscriptionId})
+
+	// Assertions
+	mockMongo.AssertExpectations(t)
+	mockKafka.AssertExpectations(t)
+	mockPicker.AssertExpectations(t)
+}
+
+func TestRepublishEventsUnThrottled(t *testing.T) {
+	// Initialize mocks
+	mockMongo := new(test.MockMongoHandler)
+	mockKafka := new(test.MockKafkaHandler)
+
+	mockPicker := new(test.MockPicker)
+	test.InjectMockPicker(mockPicker)
+
+	// Replace real handlers with mocks
+	mongo.CurrentConnection = mockMongo
+	kafka.CurrentHandler = mockKafka
+
+	// Mock data
+	subscriptionId := "sub124"
+	numDbMessages := 50
+	redeliveriesPerSecond := 0
+
+	// Set configurations for the test
+	config.Current.Republishing.BatchSize = int64(numDbMessages + 1)
+	config.Current.Republishing.ThrottlingIntervalTime = 1 * time.Second
+
+	dbMessages := test.GenerateMessages("test-topic", 1, 100, numDbMessages)
+
+	kafkaMessage := sarama.ConsumerMessage{Value: []byte("test-content")}
+
+	// Expectations for the batch
+	mockMongo.On("FindWaitingMessages", mock.Anything, mock.Anything, subscriptionId).Return(dbMessages, nil, nil).Once()
+
+	mockPicker.On("Pick", mock.AnythingOfType("*message.StatusMessage")).Return(&kafkaMessage, nil).Times(len(dbMessages))
+	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").Return(nil).Times(len(dbMessages))
+
+	// Call the function under test
+	subscription := &resource.SubscriptionResource{
+		Spec: struct {
+			Subscription resource.Subscription `json:"subscription"`
+			Environment  string                `json:"environment"`
+		}{
+			Subscription: resource.Subscription{
+				SubscriptionId:        "sub124",
+				DeliveryType:          enum.DeliveryTypeCallback,
+				Callback:              "http://new-callbackUrl/callback",
+				RedeliveriesPerSecond: redeliveriesPerSecond,
+			},
+		},
+	}
+
+	RepublishPendingEvents(subscription, RepublishingCacheEntry{SubscriptionId: subscriptionId})
+
+	// Assertions
+	mockMongo.AssertExpectations(t)
+	mockKafka.AssertExpectations(t)
+	mockPicker.AssertExpectations(t)
+}

--- a/internal/test/utils.go
+++ b/internal/test/utils.go
@@ -8,6 +8,7 @@ package test
 
 import (
 	"context"
+	"github.com/telekom/pubsub-horizon-go/message"
 	"os"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
@@ -43,4 +44,25 @@ func ClearCaches() {
 	if err != nil {
 		return
 	}
+}
+
+// GenerateMessages generates `count` StatusMessages
+// - all with the same topic
+// - Partition startPartition
+// - Offsets from startOffset ascending
+func GenerateMessages(topic string, startPartition int32, startOffset int64, count int) []message.StatusMessage {
+	msgs := make([]message.StatusMessage, count)
+	for i := 0; i < count; i++ {
+		p := startPartition
+		o := startOffset + int64(i)
+
+		msgs[i] = message.StatusMessage{
+			Topic: topic,
+			Coordinates: &message.Coordinates{
+				Partition: &p,
+				Offset:    &o,
+			},
+		}
+	}
+	return msgs
 }

--- a/internal/test/utils.go
+++ b/internal/test/utils.go
@@ -46,11 +46,7 @@ func ClearCaches() {
 	}
 }
 
-// GenerateMessages generates `count` StatusMessages
-// - all with the same topic
-// - Partition startPartition
-// - Offsets from startOffset ascending
-func GenerateMessages(topic string, startPartition int32, startOffset int64, count int) []message.StatusMessage {
+func GenerateStatusMessages(topic string, startPartition int32, startOffset int64, count int) []message.StatusMessage {
 	msgs := make([]message.StatusMessage, count)
 	for i := 0; i < count; i++ {
 		p := startPartition


### PR DESCRIPTION
Adjustment of the throttling implementation in the republishing process to eliminate the risk of a data race. Additional unit tests have been added.