### PR TITLE
fix(mongo): use cursors correctly

### DIFF
--- a/internal/handler/delivering.go
+++ b/internal/handler/delivering.go
@@ -43,9 +43,9 @@ func CheckDeliveringEvents() {
 	defer picker.Close()
 
 	for {
-		var lastCursor any
+		var lastTimestamp any
 
-		dbMessages, lastCursor, err := mongo.CurrentConnection.FindDeliveringMessagesByDeliveryType(upperThresholdTimestamp, lastCursor)
+		dbMessages, lastTimestamp, err := mongo.CurrentConnection.FindDeliveringMessagesByDeliveryType(upperThresholdTimestamp, lastTimestamp)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error while fetching DELIVERING messages from MongoDb")
 			return

--- a/internal/handler/failed.go
+++ b/internal/handler/failed.go
@@ -45,8 +45,8 @@ func CheckFailedEvents() {
 	defer picker.Close()
 
 	for {
-		var lastCursor any
-		dbMessages, _, err = mongo.CurrentConnection.FindFailedMessagesWithCallbackUrlNotFoundException(time.Now(), lastCursor)
+		var lastTimestamp any
+		dbMessages, _, err = mongo.CurrentConnection.FindFailedMessagesWithCallbackUrlNotFoundException(time.Now(), lastTimestamp)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error while fetching FAILED messages from MongoDb")
 			return

--- a/internal/mongo/interfaces.go
+++ b/internal/mongo/interfaces.go
@@ -10,9 +10,9 @@ import (
 )
 
 type HandlerInterface interface {
-	FindWaitingMessages(timestamp time.Time, lastCursor any, subscriptionId string) ([]message.StatusMessage, any, error)
-	FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastCursor any) ([]message.StatusMessage, any, error)
-	FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastCursor any, subscriptionId string) ([]message.StatusMessage, any, error)
-	FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastCursor any) ([]message.StatusMessage, any, error)
+	FindWaitingMessages(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error)
+	FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error)
+	FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error)
+	FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error)
 	FindDistinctSubscriptionsForWaitingEvents(beginTimestamp time.Time, endTimestamp time.Time) ([]string, error)
 }

--- a/internal/mongo/query.go
+++ b/internal/mongo/query.go
@@ -37,7 +37,7 @@ func (connection Connection) findMessagesByQuery(query bson.M, lastTimestamp any
 	}
 
 	var messages []message.StatusMessage
-	if err := cursor.All(ctx, messages); err != nil {
+	if err := cursor.All(ctx, &messages); err != nil {
 		log.Error().
 			Err(err).
 			Str("query", fmt.Sprintf("%+v", query)).

--- a/internal/mongo/query.go
+++ b/internal/mongo/query.go
@@ -90,7 +90,7 @@ func (connection Connection) FindDistinctSubscriptionsForWaitingEvents(beginTime
 	return castedSubscriptions, err
 }
 
-func (connection Connection) FindWaitingMessages(timestamp time.Time, lastCursor any, subscriptionId string) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindWaitingMessages(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status":         "WAITING",
 		"subscriptionId": subscriptionId,
@@ -99,10 +99,10 @@ func (connection Connection) FindWaitingMessages(timestamp time.Time, lastCursor
 		},
 	}
 
-	return connection.findMessagesByQuery(query, lastCursor)
+	return connection.findMessagesByQuery(query, lastTimestamp)
 }
 
-func (connection Connection) FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastCursor any, subscriptionId string) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status":         "PROCESSED",
 		"deliveryType":   "SERVER_SENT_EVENT",
@@ -112,10 +112,10 @@ func (connection Connection) FindProcessedMessagesByDeliveryTypeSSE(timestamp ti
 		},
 	}
 
-	return connection.findMessagesByQuery(query, lastCursor)
+	return connection.findMessagesByQuery(query, lastTimestamp)
 }
 
-func (connection Connection) FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastCursor any) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status": "DELIVERING",
 		"modified": bson.M{
@@ -123,10 +123,10 @@ func (connection Connection) FindDeliveringMessagesByDeliveryType(timestamp time
 		},
 	}
 
-	return connection.findMessagesByQuery(query, lastCursor)
+	return connection.findMessagesByQuery(query, lastTimestamp)
 }
 
-func (connection Connection) FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastCursor any) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status":    "FAILED",
 		"errorType": "de.telekom.horizon.comet.exception.CallbackUrlNotFoundException",
@@ -135,5 +135,5 @@ func (connection Connection) FindFailedMessagesWithCallbackUrlNotFoundException(
 		},
 	}
 
-	return connection.findMessagesByQuery(query, lastCursor)
+	return connection.findMessagesByQuery(query, lastTimestamp)
 }

--- a/internal/republish/republish.go
+++ b/internal/republish/republish.go
@@ -129,7 +129,7 @@ func RepublishPendingEvents(subscription *resource.SubscriptionResource, republi
 
 	cache.SetCancelStatus(subscriptionId, false)
 
-	var lastCursor any
+	var lastTimestamp any
 	for {
 		if cache.GetCancelStatus(subscriptionId) {
 			log.Info().Msgf("Republishing for subscription %s has been cancelled", subscriptionId)
@@ -141,20 +141,20 @@ func RepublishPendingEvents(subscription *resource.SubscriptionResource, republi
 		var err error
 
 		if republishEntry.OldDeliveryType == "sse" || republishEntry.OldDeliveryType == "server_sent_event" {
-			dbMessages, lastCursor, err = mongo.CurrentConnection.FindProcessedMessagesByDeliveryTypeSSE(time.Now(), lastCursor, subscriptionId)
+			dbMessages, lastTimestamp, err = mongo.CurrentConnection.FindProcessedMessagesByDeliveryTypeSSE(time.Now(), lastTimestamp, subscriptionId)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error while fetching PROCESSED messages for subscription %s from db", subscriptionId)
 			}
 			log.Debug().Msgf("Found %d PROCESSED messages in MongoDb", len(dbMessages))
 		} else {
-			dbMessages, lastCursor, err = mongo.CurrentConnection.FindWaitingMessages(time.Now(), lastCursor, subscriptionId)
+			dbMessages, lastTimestamp, err = mongo.CurrentConnection.FindWaitingMessages(time.Now(), lastTimestamp, subscriptionId)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error while fetching messages for subscription %s from db", subscriptionId)
 			}
 			log.Debug().Msgf("Found %d WAITING messages in MongoDb", len(dbMessages))
 		}
 
-		log.Debug().Msgf("Last cursor: %v", lastCursor)
+		log.Debug().Msgf("Last cursor: %v", lastTimestamp)
 
 		if len(dbMessages) == 0 {
 			break

--- a/internal/test/mongohandler_mock.go
+++ b/internal/test/mongohandler_mock.go
@@ -23,22 +23,22 @@ func (m *MockMongoHandler) FindDistinctSubscriptionsForWaitingEvents(beginTimest
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *MockMongoHandler) FindWaitingMessages(timestamp time.Time, lastCursor any, subscriptionId string) ([]message.StatusMessage, any, error) {
-	args := m.Called(timestamp, lastCursor, subscriptionId)
+func (m *MockMongoHandler) FindWaitingMessages(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
+	args := m.Called(timestamp, lastTimestamp, subscriptionId)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }
 
-func (m *MockMongoHandler) FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastCursor any) ([]message.StatusMessage, any, error) {
-	args := m.Called(timestamp, lastCursor)
+func (m *MockMongoHandler) FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
+	args := m.Called(timestamp, lastTimestamp)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }
 
-func (m *MockMongoHandler) FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastCursor any, subscriptionId string) ([]message.StatusMessage, any, error) {
-	args := m.Called(timestamp, lastCursor, subscriptionId)
+func (m *MockMongoHandler) FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
+	args := m.Called(timestamp, lastTimestamp, subscriptionId)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }
 
-func (m *MockMongoHandler) FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastCursor any) ([]message.StatusMessage, any, error) {
-	args := m.Called(timestamp, lastCursor)
+func (m *MockMongoHandler) FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
+	args := m.Called(timestamp, lastTimestamp)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }


### PR DESCRIPTION
This PR ensures that cursors are closed implicitly by reading the whole cursor using `cursor.All()`. An alternative would be a deferred call of `cursor.Close()` but reading the entries by iterating (as it was done previously) makes no sense in this specific case. I've also included a refactoring of variables with names that didn't represent the value they held.