### PR TITLE
fix(hazelcast): improve context passing in ForceDelete

### DIFF
--- a/internal/api/circuitbreaker.go
+++ b/internal/api/circuitbreaker.go
@@ -88,7 +88,10 @@ func putCloseCircuitBreakerById(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusNotFound).SendString("Circuit breaker message not found for subscription-id " + subscriptionId)
 	}
 
-	republish.ForceDelete(ctx.Context(), cbMessage.SubscriptionId)
+	if err = republish.ForceDelete(ctx.Context(), cbMessage.SubscriptionId); err != nil {
+		log.Error().Err(err).Msgf("Error while deleting republishing entry for subscription %s", subscriptionId)
+		return ctx.Status(fiber.StatusInternalServerError).SendString("Error deleting the republishing entry")
+	}
 	cache.SetCancelStatus(subscriptionId, true)
 
 	// Set new republishing entry to pick the last waiting

--- a/internal/circuitbreaker/circuitbreaker.go
+++ b/internal/circuitbreaker/circuitbreaker.go
@@ -161,7 +161,9 @@ func forceDeleteRepublishingEntry(cbMessage message.CircuitBreakerMessage, hcDat
 		}
 		if republishCacheEntry.SubscriptionChange != true {
 			log.Debug().Msgf("RepublishingCacheEntry found for subscriptionId %s", cbMessage.SubscriptionId)
-			republish.ForceDelete(hcData.Ctx, cbMessage.SubscriptionId)
+			if err := republish.ForceDelete(hcData.Ctx, cbMessage.SubscriptionId); err != nil {
+				return err
+			}
 			cache.SetCancelStatus(cbMessage.SubscriptionId, true)
 		}
 	}

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -158,6 +158,7 @@ func TestSubscriptionListener_OnUpdate_CallbackUrl(t *testing.T) {
 	republishMockMap.On("IsLocked", mock.Anything, subscriptionId).Return(true, nil)
 	republishMockMap.On("ForceUnlock", mock.Anything, subscriptionId).Return(nil)
 	republishMockMap.On("Delete", mock.Anything, subscriptionId).Return(nil)
+	republishMockMap.On("NewLockContext", mock.Anything).Return(context.Background())
 	republishMockMap.On("Set", mock.Anything, subscriptionId, republish.RepublishingCacheEntry{
 		SubscriptionId:     subscriptionId,
 		OldDeliveryType:    "",
@@ -218,6 +219,7 @@ func TestSubscriptionListener_OnUpdate_RedeliveriesPerSecond(t *testing.T) {
 	republishMockMap.On("IsLocked", mock.Anything, subscriptionId).Return(true, nil)
 	republishMockMap.On("ForceUnlock", mock.Anything, subscriptionId).Return(nil)
 	republishMockMap.On("Delete", mock.Anything, subscriptionId).Return(nil)
+	republishMockMap.On("NewLockContext", mock.Anything).Return(context.Background())
 	republishMockMap.On("Set", mock.Anything, subscriptionId, republish.RepublishingCacheEntry{
 		SubscriptionId:     subscriptionId,
 		SubscriptionChange: true,
@@ -243,6 +245,7 @@ func TestSubscriptionListener_OnDelete(t *testing.T) {
 	republishMockMap.On("IsLocked", mock.Anything, subscriptionId).Return(true, nil)
 	republishMockMap.On("ForceUnlock", mock.Anything, subscriptionId).Return(nil)
 	republishMockMap.On("Delete", mock.Anything, subscriptionId).Return(nil)
+	republishMockMap.On("NewLockContext", mock.Anything).Return(context.Background())
 
 	event := &hazelcast.EntryNotified{Key: subscriptionId}
 	listener := &SubscriptionListener{}

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -5,6 +5,7 @@
 package listener
 
 import (
+	"context"
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -74,6 +75,7 @@ func TestSubscriptionListener_OnUpdate_DeliveryTypeToSSE(t *testing.T) {
 	republishMockMap.On("IsLocked", mock.Anything, subscriptionId).Return(true, nil)
 	republishMockMap.On("ForceUnlock", mock.Anything, subscriptionId).Return(nil)
 	republishMockMap.On("Delete", mock.Anything, subscriptionId).Return(nil)
+	republishMockMap.On("NewLockContext", mock.Anything).Return(context.Background())
 
 	republishMockMap.On("Set", mock.Anything, subscriptionId, republish.RepublishingCacheEntry{
 		SubscriptionId:     subscriptionId,

--- a/internal/republish/republish.go
+++ b/internal/republish/republish.go
@@ -263,20 +263,11 @@ func ForceDelete(ctx context.Context, subscriptionId string) error {
 	defer cancel()
 	lockCtx := cache.RepublishingCache.NewLockContext(ctxWithTimeout)
 
-	// Check if the entry is locked
-	isLocked, err := cache.RepublishingCache.IsLocked(lockCtx, subscriptionId)
+	// Unlock it
+	err := cache.RepublishingCache.ForceUnlock(lockCtx, subscriptionId)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error checking if RepublishingCacheEntry is locked for subscriptionId %s", subscriptionId)
+		log.Error().Err(err).Msgf("Error force-unlocking RepublishingCacheEntry for subscriptionId %s", subscriptionId)
 		return err
-	}
-
-	// If locked, unlock it
-	if isLocked {
-		err = cache.RepublishingCache.ForceUnlock(lockCtx, subscriptionId)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error force-unlocking RepublishingCacheEntry for subscriptionId %s", subscriptionId)
-			return err
-		}
 	}
 
 	// Delete the entry

--- a/internal/republish/republish_test.go
+++ b/internal/republish/republish_test.go
@@ -204,10 +204,11 @@ func Test_ForceDelete_RepublishingEntryLocked(t *testing.T) {
 	cache.RepublishingCache.Lock(ctx, testSubscriptionId)
 
 	// call the function under test
-	ForceDelete(ctx, testSubscriptionId)
+	err := ForceDelete(ctx, testSubscriptionId)
 
 	// Assertions
 	assertions.False(cache.RepublishingCache.ContainsKey(ctx, testSubscriptionId))
+	assertions.NoError(err, "error should be nil when deleting a locked republishing entry")
 }
 
 func Test_ForceDelete_RepublishingEntryUnlocked(t *testing.T) {
@@ -221,10 +222,11 @@ func Test_ForceDelete_RepublishingEntryUnlocked(t *testing.T) {
 	cache.RepublishingCache.Set(ctx, testSubscriptionId, republishingCacheEntry)
 
 	// call the function under test
-	ForceDelete(ctx, testSubscriptionId)
+	err := ForceDelete(ctx, testSubscriptionId)
 
 	// Assertions
 	assertions.False(cache.RepublishingCache.ContainsKey(ctx, testSubscriptionId))
+	assertions.NoError(err, "error should be nil when deleting an unlocked republishing entry")
 }
 
 func TestRepublishEventsThrottled(t *testing.T) {


### PR DESCRIPTION
This PR introduces consistent context usage across go routines that utilize hazelcast locking