### PR TITLE
fix(circuit-breaker): fix problem with hanging circuit breakers

### DIFF
--- a/internal/circuitbreaker/circuitbreaker.go
+++ b/internal/circuitbreaker/circuitbreaker.go
@@ -161,10 +161,10 @@ func forceDeleteRepublishingEntry(cbMessage message.CircuitBreakerMessage, hcDat
 		}
 		if republishCacheEntry.SubscriptionChange != true {
 			log.Debug().Msgf("RepublishingCacheEntry found for subscriptionId %s", cbMessage.SubscriptionId)
+			cache.SetCancelStatus(cbMessage.SubscriptionId, true)
 			if err := republish.ForceDelete(hcData.Ctx, cbMessage.SubscriptionId); err != nil {
 				return err
 			}
-			cache.SetCancelStatus(cbMessage.SubscriptionId, true)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ func setDefaults() {
 	viper.SetDefault("healthCheck.coolDownTime", "30s")
 
 	viper.SetDefault("republishing.checkInterval", "30s")
+	viper.SetDefault("republishing.initialDelay", "3s")
 	viper.SetDefault("republishing.batchSize", 10)
 	viper.SetDefault("republishing.throttlingIntervalTime", "1s")
 	viper.SetDefault("republishing.deliveringStatesOffset", "70m")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -25,6 +25,7 @@ type Configuration struct {
 
 type CircuitBreaker struct {
 	OpenCheckInterval       time.Duration `mapstructure:"openCheckInterval"`
+	InitialDelay            time.Duration `mapstructure:"initialDelay"`
 	OpenLoopDetectionPeriod time.Duration `mapstructure:"openLoopDetectionPeriod"`
 	ExponentialBackoffBase  time.Duration `mapstructure:"exponentialBackoffBase"`
 	ExponentialBackoffMax   time.Duration `mapstructure:"exponentialBackoffMax"`
@@ -37,6 +38,7 @@ type HealthCheck struct {
 
 type Republishing struct {
 	CheckInterval          time.Duration `mapstructure:"checkInterval"`
+	InitialDelay           time.Duration `mapstructure:"initialDelay"`
 	BatchSize              int64         `mapstructure:"batchSize"`
 	ThrottlingIntervalTime time.Duration `mapstructure:"throttlingIntervalTime"`
 	DeliveringStatesOffset time.Duration `mapstructure:"deliveringStatesOffset"`
@@ -99,7 +101,9 @@ type Handler struct {
 }
 
 type WaitingHandler struct {
-	Handler
+	Enabled       bool          `mapstructure:"enabled"`
+	Interval      time.Duration `mapstructure:"interval"`
+	InitialDelay  time.Duration `mapstructure:"initialDelay"`
 	MinMessageAge time.Duration `mapstructure:"minMessageAge"`
 	MaxMessageAge time.Duration `mapstructure:"maxMessageAge"`
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -25,7 +25,6 @@ type Configuration struct {
 
 type CircuitBreaker struct {
 	OpenCheckInterval       time.Duration `mapstructure:"openCheckInterval"`
-	InitialDelay            time.Duration `mapstructure:"initialDelay"`
 	OpenLoopDetectionPeriod time.Duration `mapstructure:"openLoopDetectionPeriod"`
 	ExponentialBackoffBase  time.Duration `mapstructure:"exponentialBackoffBase"`
 	ExponentialBackoffMax   time.Duration `mapstructure:"exponentialBackoffMax"`

--- a/internal/handler/delivering.go
+++ b/internal/handler/delivering.go
@@ -16,7 +16,7 @@ import (
 )
 
 func CheckDeliveringEvents() {
-	log.Debug().Msgf("Republish messages in state DELIVERING")
+	log.Debug().Msgf("DeliveringHandler: Republish messages in state DELIVERING")
 
 	var ctx = cache.HandlerCache.NewLockContext(context.Background())
 

--- a/internal/handler/failed.go
+++ b/internal/handler/failed.go
@@ -17,7 +17,7 @@ import (
 )
 
 func CheckFailedEvents() {
-	log.Debug().Msgf("Republish messages in state FAILED")
+	log.Debug().Msgf("FailedHandler: Republish messages in state FAILED")
 
 	var ctx = cache.HandlerCache.NewLockContext(context.Background())
 

--- a/internal/handler/waiting.go
+++ b/internal/handler/waiting.go
@@ -29,7 +29,7 @@ var WaitingHandlerService WaitingHandlerInterface = new(waitingHandler)
 
 // CheckWaitingEvents checks for events stuck in the WAITING state and creates a republishing entry if necessary.
 func (waitingHandler *waitingHandler) CheckWaitingEvents() {
-	log.Debug().Msgf("WaitingHandler: Republish messages stucked in state WAITING")
+	log.Debug().Msgf("WaitingHandler: Republish messages stuck in state WAITING")
 
 	minMessageAge := config.Current.Handlers.Waiting.MinMessageAge
 	maxMessageAge := config.Current.Handlers.Waiting.MaxMessageAge
@@ -51,7 +51,7 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 	// Get all subscriptions (distinct) for messages in state WAITING from db
 	dbSubscriptionsForWaitingEvents, err := mongo.CurrentConnection.FindDistinctSubscriptionsForWaitingEvents(time.Now().Add(-maxMessageAge), time.Now().Add(-minMessageAge))
 	if err != nil {
-		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching distinct subscriptions for events stucked in state WAITING from db")
+		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching distinct subscriptions for events stuck in state WAITING from db")
 		return
 	}
 
@@ -64,7 +64,7 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 	// Get all republishing cache entries
 	republishingSubscriptionsMap, err := WaitingHandlerService.GetRepublishingSubscriptionsMap()
 	if err != nil {
-		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching rebublishing cache entries for events stucked in state WAITING")
+		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching rebublishing cache entries for events stuck in state WAITING")
 		return
 	}
 	log.Debug().Msgf("WaitingHandler: Found %d rebublishing entries: %v", len(republishingSubscriptionsMap), republishingSubscriptionsMap)
@@ -72,18 +72,18 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 	// Get all circuit-breaker entries with status OPEN
 	circuitBreakerSubscriptionsMap, err := WaitingHandlerService.GetCircuitBreakerSubscriptionsMap()
 	if err != nil {
-		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching circuit breaker cache entries for events stucked in state WAITING")
+		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching circuit breaker cache entries for events stuck in state WAITING")
 		return
 	}
 	log.Debug().Msgf("WaitingHandler: Found %d circuitbreaker entries in state OPEN: %v", len(circuitBreakerSubscriptionsMap), circuitBreakerSubscriptionsMap)
 
 	// Check if subscription is in republishing cache or in circuit breaker cache. If not create a republishing cache entry
 	for _, subscriptionId := range dbSubscriptionsForWaitingEvents {
-		log.Debug().Msgf("WaitingHandler: Checking subscription for events stucked in state WAITING. subscription: %v", subscriptionId)
+		log.Debug().Msgf("WaitingHandler: Checking subscription for events stuck in state WAITING. subscription: %v", subscriptionId)
 		_, inRepublishing := republishingSubscriptionsMap[subscriptionId]
 		_, inCircuitBreaker := circuitBreakerSubscriptionsMap[subscriptionId]
 		if !inRepublishing && !inCircuitBreaker {
-			log.Warn().Msgf("WaitingHandler: Subscription %v has waiting messages and no circuitbreaker entry and no republishing entry!. Creating republishing entry for events stucked in state WAITING", subscriptionId)
+			log.Warn().Msgf("WaitingHandler: Subscription %v has waiting messages and no circuitbreaker entry and no republishing entry!. Creating republishing entry for events stuck in state WAITING", subscriptionId)
 
 			// Create republishing cache entry for subscription with stuck waiting events
 			republishingCacheEntry := republish.RepublishingCacheEntry{
@@ -92,13 +92,13 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 				PostponedUntil:   time.Now(),
 			}
 			if err := cache.RepublishingCache.Set(context.Background(), subscriptionId, republishingCacheEntry); err != nil {
-				log.Error().Err(err).Msgf("WaitingHandler: Error while creating RepublishingCacheEntry entry for events stucked in state WAITING. subscriptionId: %s", subscriptionId)
+				log.Error().Err(err).Msgf("WaitingHandler: Error while creating RepublishingCacheEntry entry for events stuck in state WAITING. subscriptionId: %s", subscriptionId)
 				continue
 			}
-			log.Debug().Msgf("WaitingHandler: Successfully created RepublishingCacheEntry entry for for events stucked in state WAITING. subscriptionId: %s republishingEntry: %+v", subscriptionId, republishingCacheEntry)
+			log.Debug().Msgf("WaitingHandler: Successfully created RepublishingCacheEntry entry for for events stuck in state WAITING. subscriptionId: %s republishingEntry: %+v", subscriptionId, republishingCacheEntry)
 		}
 	}
-	log.Debug().Msgf("WaitingHandler: Finished republishing messages stucked in state WAITING")
+	log.Debug().Msgf("WaitingHandler: Finished republishing messages stuck in state WAITING")
 }
 
 // GetCircuitBreakerSubscriptionsMap returns a map of subscriptions with open circuit breaker entries.

--- a/internal/republish/republish.go
+++ b/internal/republish/republish.go
@@ -264,6 +264,7 @@ func ForceDelete(ctx context.Context, subscriptionId string) error {
 	lockCtx := cache.RepublishingCache.NewLockContext(ctxWithTimeout)
 
 	// Unlock it
+	log.Debug().Msgf("Attempting to force unlock RepublishingCacheEntry for subscriptionId %s", subscriptionId)
 	err := cache.RepublishingCache.ForceUnlock(lockCtx, subscriptionId)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error force-unlocking RepublishingCacheEntry for subscriptionId %s", subscriptionId)
@@ -271,6 +272,7 @@ func ForceDelete(ctx context.Context, subscriptionId string) error {
 	}
 
 	// Delete the entry
+	log.Debug().Msgf("Attempting to delete RepublishingCacheEntry for subscriptionId %s", subscriptionId)
 	err = cache.RepublishingCache.Delete(lockCtx, subscriptionId)
 	if err != nil {
 		log.Error().Err(err).Msgf("Error deleting RepublishingCacheEntry for subscriptionId %s", subscriptionId)

--- a/internal/republish/republish.go
+++ b/internal/republish/republish.go
@@ -79,7 +79,7 @@ func HandleRepublishingEntry(subscription *resource.SubscriptionResource) {
 		log.Debug().Msgf("Could not acquire lock for RepublishingCacheEntry, skipping entry for subscriptionId %s", subscriptionId)
 		return
 	}
-	if acquired, _ = cache.RepublishingCache.TryLockWithTimeout(ctx, subscriptionId, 10*time.Millisecond); !acquired {
+	if acquired, _ = cache.RepublishingCache.TryLockWithTimeout(ctx, subscriptionId, 100*time.Millisecond); !acquired {
 		log.Debug().Msgf("Could not acquire lock for RepublishingCacheEntry, skipping entry for subscriptionId %s", subscriptionId)
 		return
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -77,7 +77,7 @@ func StartScheduler() {
 // and processes each entry asynchronously. It checks if the corresponding subscription exists
 // and handles the open circuit breaker entry if the subscription is found.
 func checkOpenCircuitBreakers() {
-	log.Debug().Msgf("CircuitBreaker Loop: Checking cricuitBreaker entries")
+	log.Debug().Msgf("CircuitBreaker-Loop: Checking cricuitBreaker entries")
 
 	// Get all CircuitBreaker entries with status OPEN
 	statusQuery := predicate.Equal("status", string(enum.CircuitBreakerStatusOpen))

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -45,6 +45,7 @@ func StartScheduler() {
 		}
 	}
 
+	// Schedule the task for checking messages stuck in state DELIVERING
 	if deliveringHandler := config.Current.Handlers.Delivering; deliveringHandler.Enabled {
 		initialDelay := time.Now().Add(deliveringHandler.InitialDelay)
 		if _, err := scheduler.Every(deliveringHandler.Interval).StartAt(initialDelay).Do(handler.CheckDeliveringEvents); err != nil {
@@ -52,6 +53,7 @@ func StartScheduler() {
 		}
 	}
 
+	// Schedule the task for checking messages in state FAILED
 	if failedHandler := config.Current.Handlers.Failed; failedHandler.Enabled {
 		initialDelay := time.Now().Add(failedHandler.InitialDelay)
 		if _, err := scheduler.Every(failedHandler.Interval).StartAt(initialDelay).Do(handler.CheckFailedEvents); err != nil {
@@ -59,6 +61,7 @@ func StartScheduler() {
 		}
 	}
 
+	// Schedule the task for checking messages stuck in state WAITING
 	if waitingHandler := config.Current.Handlers.Waiting; waitingHandler.Enabled {
 		initialDelay := time.Now().Add(waitingHandler.InitialDelay)
 		if _, err := scheduler.Every(waitingHandler.Interval).StartAt(initialDelay).Do(handler.WaitingHandlerService.CheckWaitingEvents); err != nil {


### PR DESCRIPTION
This PR fixes issues with circuitbreaker handling getting stuck in the deleting operation by:
- Decoupling scheduled tasks for republishing handling from circuitbreaker handling
- Attempting to lock the republishing entry only if it isn't already locked
- Setting the republishing cancel status before force-deleting the republishing entry