### PR TITLE
chore(deps): configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      opentelemetry:
+        patterns:
+          - go.opentelemetry.io/*
+          -
+      docker:
+        patterns:
+          - github.com/docker/*
+      fiber:
+        patterns:
+          - github.com/gofiber/*
+      kubernetes:
+        patterns:
+          - k8s.io/*

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -34,6 +34,12 @@ SPDX-FileCopyrightText = "Copyright 2024 Deutsche Telekom IT GmbH"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
+path = ".github/dependabot.yml"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Copyright 2024 Deutsche Telekom AG"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
 path = "REUSE.toml"
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Copyright 2024 Deutsche Telekom IT GmbH"


### PR DESCRIPTION
This PR provides an initial configuration for dependabot to keep track of dependency updates.