### PR TITLE
fix: clean up orphaned circuit breakers and prevent nil pointer panic

### DIFF
--- a/internal/api/circuitbreaker.go
+++ b/internal/api/circuitbreaker.go
@@ -118,12 +118,17 @@ func populateCircuitBreakerResponse(res *CircuitBreakerResponse) {
 		log.Warn().Fields(map[string]any{
 			"subscriptionId": res.SubscriptionId,
 		}).Msg("could not populate circuit-breaker response with subscription data")
-	} else {
-		if subscription != nil {
-			res.SubscriberId = subscription.Spec.Subscription.SubscriberId
-			res.PublisherId = subscription.Spec.Subscription.PublisherId
-		}
+		return
 	}
+	if subscription == nil {
+		log.Warn().Fields(map[string]any{
+			"subscriptionId": res.SubscriptionId,
+		}).Msg("subscription not found, skipping circuit-breaker response population")
+		return
+	}
+
+	res.SubscriberId = subscription.Spec.Subscription.SubscriberId
+	res.PublisherId = subscription.Spec.Subscription.PublisherId
 
 	var healthCheckCache = cache.HealthCheckCache.(*hazelcast.Map)
 	var healthCheckMethod = utils.IfThenElse(subscription.Spec.Subscription.EnforceGetHealthCheck, fiber.MethodGet, fiber.MethodHead)
@@ -135,9 +140,8 @@ func populateCircuitBreakerResponse(res *CircuitBreakerResponse) {
 			"subscriptionId": res.SubscriptionId,
 		}).Err(err).Msg("could not populate circuit-breaker response with healthcheck data")
 		return
-	} else {
-		if healthCheck != nil {
-			res.HealthCheck = healthCheck.(healthcheck.HealthCheckCacheEntry)
-		}
+	}
+	if healthCheck != nil {
+		res.HealthCheck = healthCheck.(healthcheck.HealthCheckCacheEntry)
 	}
 }

--- a/internal/api/circuitbreaker_test.go
+++ b/internal/api/circuitbreaker_test.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"fmt"
+	"pubsub-horizon-golaris/internal/cache"
+	"pubsub-horizon-golaris/internal/config"
+	"pubsub-horizon-golaris/internal/test"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/telekom/pubsub-horizon-go/enum"
+	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/resource"
+)
+
+// Fix 3: populateCircuitBreakerResponse has a nil pointer dereference on line 129
+// when the subscription is not found. It accesses subscription.Spec without nil check.
+
+func TestMakeCircuitBreakerResponse_PanicsWhenSubscriptionNil(t *testing.T) {
+	config.Current = test.BuildTestConfig()
+
+	subCache := new(test.SubscriptionMockCache)
+	cache.SubscriptionCache = subCache
+
+	// Subscription does not exist (deleted/orphaned)
+	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "orphaned-sub").
+		Return((*resource.SubscriptionResource)(nil), nil)
+
+	cbMsg := &message.CircuitBreakerMessage{
+		SubscriptionId: "orphaned-sub",
+		Status:         enum.CircuitBreakerStatusClosed,
+		EventType:      "test.event.v1",
+		Environment:    "playground",
+	}
+
+	// After fix, this should return gracefully with empty SubscriberId (no panic).
+	assert.NotPanics(t, func() {
+		resp := makeCircuitBreakerResponse(cbMsg)
+		assert.Empty(t, resp.SubscriberId, "subscriberId should be empty when subscription not found")
+		assert.Empty(t, resp.PublisherId, "publisherId should be empty when subscription not found")
+	})
+}
+
+func TestMakeCircuitBreakerResponse_WithSubscriptionError(t *testing.T) {
+	config.Current = test.BuildTestConfig()
+
+	subCache := new(test.SubscriptionMockCache)
+	cache.SubscriptionCache = subCache
+
+	// Subscription cache returns an error
+	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "error-sub").
+		Return((*resource.SubscriptionResource)(nil), fmt.Errorf("hazelcast connection error"))
+
+	cbMsg := &message.CircuitBreakerMessage{
+		SubscriptionId: "error-sub",
+		Status:         enum.CircuitBreakerStatusOpen,
+		EventType:      "test.event.v1",
+		Environment:    "playground",
+	}
+
+	// Should return gracefully even when subscription cache errors
+	assert.NotPanics(t, func() {
+		resp := makeCircuitBreakerResponse(cbMsg)
+		assert.Empty(t, resp.SubscriberId, "subscriberId should be empty on error")
+	})
+}

--- a/internal/api/circuitbreaker_test.go
+++ b/internal/api/circuitbreaker_test.go
@@ -17,10 +17,7 @@ import (
 	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
-// Fix 3: populateCircuitBreakerResponse has a nil pointer dereference on line 129
-// when the subscription is not found. It accesses subscription.Spec without nil check.
-
-func TestMakeCircuitBreakerResponse_PanicsWhenSubscriptionNil(t *testing.T) {
+func TestMakeCircuitBreakerResponse_NoPanicWhenSubscriptionNil(t *testing.T) {
 	config.Current = test.BuildTestConfig()
 
 	subCache := new(test.SubscriptionMockCache)

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -114,6 +114,17 @@ func (sl *SubscriptionListener) OnDelete(event *hazelcast.EntryNotified) {
 			return
 		}
 	}
+
+	cbMessage, err := cache.CircuitBreakerCache.Get(config.Current.Hazelcast.Caches.CircuitBreakerCache, key)
+	if err != nil {
+		logger.Error().Err(err).Msgf("Failed to get circuit breaker for subscriptionId %s on OnDelete", key)
+		return
+	}
+	if cbMessage != nil {
+		if err := cache.CircuitBreakerCache.Delete(config.Current.Hazelcast.Caches.CircuitBreakerCache, key); err != nil {
+			logger.Error().Err(err).Msgf("Failed to delete circuit breaker for subscriptionId %s on OnDelete", key)
+		}
+	}
 }
 
 // OnError handles any errors encountered by SubscriptionListener.

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -105,13 +105,9 @@ func (sl *SubscriptionListener) OnDelete(event *hazelcast.EntryNotified) {
 	optionalEntry, err := cache.RepublishingCache.Get(context.Background(), key)
 	if err != nil {
 		logger.Error().Msgf("failed with err: %v to get republishing cache", err)
-		return
-	}
-
-	if optionalEntry != nil {
+	} else if optionalEntry != nil {
 		if err := republish.ForceDelete(context.Background(), key); err != nil {
 			logger.Error().Err(err).Msgf("Failed to delete republishing cache entry for subscriptionId %s on OnDelete", key)
-			return
 		}
 	}
 

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -6,6 +6,7 @@ package listener
 
 import (
 	"context"
+	"fmt"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/republish"
@@ -317,6 +318,29 @@ func TestSubscriptionListener_OnDelete_DeletesCircuitBreakerAndRepublishing(t *t
 	listener.OnDelete(event)
 
 	republishMockMap.AssertCalled(t, "Delete", mock.Anything, subscriptionId)
+	circuitBreakerCache.AssertCalled(t, "Delete", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId)
+}
+
+func TestSubscriptionListener_OnDelete_CBCleanupProceedsWhenRepublishingFails(t *testing.T) {
+	subscriptionId := "test-subscription-id"
+
+	republishMockMap, circuitBreakerCache := setupMocks()
+
+	// Republishing cache Get fails
+	republishMockMap.On("Get", mock.Anything, subscriptionId).Return(nil, fmt.Errorf("hazelcast connection error"))
+
+	// Circuit breaker exists and should still be cleaned up
+	cbMessage := &message.CircuitBreakerMessage{
+		SubscriptionId: subscriptionId,
+		Status:         enum.CircuitBreakerStatusOpen,
+	}
+	circuitBreakerCache.On("Get", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(cbMessage, nil)
+	circuitBreakerCache.On("Delete", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(nil)
+
+	event := &hazelcast.EntryNotified{Key: subscriptionId}
+	listener := &SubscriptionListener{}
+	listener.OnDelete(event)
+
 	circuitBreakerCache.AssertCalled(t, "Delete", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId)
 }
 

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -250,7 +250,7 @@ func TestHandleDeliveryTypeChangeFromSSEToCallback_NoRepublishingEntry(t *testin
 func TestSubscriptionListener_OnDelete(t *testing.T) {
 	subscriptionId := "test-subscription-id"
 
-	republishMockMap, _ := setupMocks()
+	republishMockMap, circuitBreakerCache := setupMocks()
 	mockEntry := &republish.RepublishingCacheEntry{SubscriptionId: subscriptionId}
 	republishMockMap.On("Get", mock.Anything, subscriptionId).Return(mockEntry, nil)
 	republishMockMap.On("IsLocked", mock.Anything, subscriptionId).Return(true, nil)
@@ -258,10 +258,82 @@ func TestSubscriptionListener_OnDelete(t *testing.T) {
 	republishMockMap.On("Delete", mock.Anything, subscriptionId).Return(nil)
 	republishMockMap.On("NewLockContext", mock.Anything).Return(context.Background())
 
+	// No circuit breaker for this subscription
+	circuitBreakerCache.On("Get", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(nil, nil)
+
 	event := &hazelcast.EntryNotified{Key: subscriptionId}
 	listener := &SubscriptionListener{}
 	listener.OnDelete(event)
 
 	republishMockMap.AssertCalled(t, "Get", mock.Anything, subscriptionId)
 	republishMockMap.AssertCalled(t, "Delete", mock.Anything, subscriptionId)
+}
+
+func TestSubscriptionListener_OnDelete_DeletesCircuitBreaker(t *testing.T) {
+	subscriptionId := "test-subscription-id"
+
+	republishMockMap, circuitBreakerCache := setupMocks()
+
+	// No republishing entry
+	republishMockMap.On("Get", mock.Anything, subscriptionId).Return(nil, nil)
+
+	// Circuit breaker exists for this subscription
+	cbMessage := &message.CircuitBreakerMessage{
+		SubscriptionId: subscriptionId,
+		Status:         enum.CircuitBreakerStatusOpen,
+	}
+	circuitBreakerCache.On("Get", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(cbMessage, nil)
+	circuitBreakerCache.On("Delete", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(nil)
+
+	event := &hazelcast.EntryNotified{Key: subscriptionId}
+	listener := &SubscriptionListener{}
+	listener.OnDelete(event)
+
+	circuitBreakerCache.AssertCalled(t, "Get", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId)
+	circuitBreakerCache.AssertCalled(t, "Delete", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId)
+}
+
+func TestSubscriptionListener_OnDelete_DeletesCircuitBreakerAndRepublishing(t *testing.T) {
+	subscriptionId := "test-subscription-id"
+
+	republishMockMap, circuitBreakerCache := setupMocks()
+
+	// Both republishing and circuit breaker entries exist
+	republishMockMap.On("Get", mock.Anything, subscriptionId).Return(&republish.RepublishingCacheEntry{SubscriptionId: subscriptionId}, nil)
+	republishMockMap.On("IsLocked", mock.Anything, subscriptionId).Return(true, nil)
+	republishMockMap.On("ForceUnlock", mock.Anything, subscriptionId).Return(nil)
+	republishMockMap.On("Delete", mock.Anything, subscriptionId).Return(nil)
+	republishMockMap.On("NewLockContext", mock.Anything).Return(context.Background())
+
+	cbMessage := &message.CircuitBreakerMessage{
+		SubscriptionId: subscriptionId,
+		Status:         enum.CircuitBreakerStatusClosed,
+	}
+	circuitBreakerCache.On("Get", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(cbMessage, nil)
+	circuitBreakerCache.On("Delete", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(nil)
+
+	event := &hazelcast.EntryNotified{Key: subscriptionId}
+	listener := &SubscriptionListener{}
+	listener.OnDelete(event)
+
+	republishMockMap.AssertCalled(t, "Delete", mock.Anything, subscriptionId)
+	circuitBreakerCache.AssertCalled(t, "Delete", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId)
+}
+
+func TestSubscriptionListener_OnDelete_NoCBEntry(t *testing.T) {
+	subscriptionId := "test-subscription-id"
+
+	republishMockMap, circuitBreakerCache := setupMocks()
+
+	republishMockMap.On("Get", mock.Anything, subscriptionId).Return(nil, nil)
+
+	// No circuit breaker exists
+	circuitBreakerCache.On("Get", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId).Return(nil, nil)
+
+	event := &hazelcast.EntryNotified{Key: subscriptionId}
+	listener := &SubscriptionListener{}
+	listener.OnDelete(event)
+
+	circuitBreakerCache.AssertCalled(t, "Get", config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId)
+	circuitBreakerCache.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything)
 }

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -53,9 +53,8 @@ func PopulateFromCache() {
 	}
 
 	for _, circuitBreaker := range circuitBreakers {
-		var open = circuitBreaker.Status == enum.CircuitBreakerStatusOpen
 		var subscriberId = lookupSubscriberId(circuitBreaker.SubscriptionId)
-		recordCircuitBreaker(circuitBreaker.SubscriptionId, subscriberId, circuitBreaker.EventType, circuitBreaker.Environment, open)
+		recordCircuitBreaker(circuitBreaker.SubscriptionId, subscriberId, circuitBreaker.EventType, circuitBreaker.Environment, true)
 	}
 }
 

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -47,7 +47,7 @@ func recordCircuitBreaker(subscriptionId string, subscriberId string, eventType 
 
 func PopulateFromCache() {
 	var cbc = cache.CircuitBreakerCache
-	circuitBreakers, err := cbc.GetQuery(config.Current.Hazelcast.Caches.CircuitBreakerCache, predicate.True())
+	circuitBreakers, err := cbc.GetQuery(config.Current.Hazelcast.Caches.CircuitBreakerCache, predicate.Equal("status", string(enum.CircuitBreakerStatusOpen)))
 	if err != nil {
 		log.Warn().Err(err).Msg("could initialize metrics from circuit-breakers map")
 	}

--- a/internal/metrics/registry_test.go
+++ b/internal/metrics/registry_test.go
@@ -1,0 +1,165 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"pubsub-horizon-golaris/internal/cache"
+	"pubsub-horizon-golaris/internal/config"
+	"pubsub-horizon-golaris/internal/test"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/telekom/pubsub-horizon-go/enum"
+	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/resource"
+)
+
+// Fix 2: PopulateFromCache should only load OPEN circuit breakers, not all.
+// Currently it uses predicate.True() which loads stale CLOSED entries too.
+
+func resetMetrics() {
+	registry = prometheus.NewRegistry()
+	openCircuitBreakers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "open_circuit_breakers",
+		Help:      "The amount of open circuit-breakers.",
+		Namespace: namespace,
+	}, []string{"subscriptionId", "subscriberId", "eventType", "environment"})
+	registry.MustRegister(openCircuitBreakers)
+}
+
+func TestPopulateFromCache_OnlyOpenCircuitBreakers(t *testing.T) {
+	resetMetrics()
+	config.Current = test.BuildTestConfig()
+	config.Current.Metrics.Enabled = true
+
+	cbCache := new(test.CircuitBreakerMockCache)
+	cache.CircuitBreakerCache = cbCache
+
+	subCache := new(test.SubscriptionMockCache)
+	cache.SubscriptionCache = subCache
+
+	openCB := message.CircuitBreakerMessage{
+		SubscriptionId: "open-sub-id",
+		Status:         enum.CircuitBreakerStatusOpen,
+		EventType:      "test.event.v1",
+		Environment:    "integration",
+	}
+	// After fix, PopulateFromCache uses predicate.Equal("status", "OPEN") so only open CBs are returned.
+	cbCache.On("GetQuery", config.Current.Hazelcast.Caches.CircuitBreakerCache, mock.Anything).
+		Return([]message.CircuitBreakerMessage{openCB}, nil)
+
+	subscription := &resource.SubscriptionResource{
+		Spec: struct {
+			Subscription resource.Subscription `json:"subscription"`
+			Environment  string                `json:"environment"`
+		}{
+			Subscription: resource.Subscription{
+				SubscriberId: "test-subscriber",
+			},
+		},
+	}
+	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "open-sub-id").Return(subscription, nil)
+
+	PopulateFromCache()
+
+	// Verify the open CB was recorded with correct subscriberId
+	metrics, _ := registry.Gather()
+	foundOpen := false
+	foundClosed := false
+	for _, mf := range metrics {
+		if mf.GetName() == "golaris_open_circuit_breakers" {
+			for _, m := range mf.GetMetric() {
+				for _, label := range m.GetLabel() {
+					if label.GetName() == "subscriptionId" && label.GetValue() == "open-sub-id" {
+						foundOpen = true
+						assert.Equal(t, float64(1), m.GetGauge().GetValue(), "OPEN CB should have value 1")
+					}
+					if label.GetName() == "subscriptionId" && label.GetValue() == "closed-sub-id" {
+						foundClosed = true
+					}
+				}
+			}
+		}
+	}
+	assert.True(t, foundOpen, "open-sub-id metric should be present")
+	assert.False(t, foundClosed, "closed-sub-id should not be loaded (only OPEN CBs are populated)")
+}
+
+func TestPopulateFromCache_OrphanedCBGetsUnknownSubscriberId(t *testing.T) {
+	resetMetrics()
+	config.Current = test.BuildTestConfig()
+	config.Current.Metrics.Enabled = true
+
+	cbCache := new(test.CircuitBreakerMockCache)
+	cache.CircuitBreakerCache = cbCache
+
+	subCache := new(test.SubscriptionMockCache)
+	cache.SubscriptionCache = subCache
+
+	orphanedCB := message.CircuitBreakerMessage{
+		SubscriptionId: "orphaned-sub-id",
+		Status:         enum.CircuitBreakerStatusClosed,
+		EventType:      "test.event.v1",
+		Environment:    "playground",
+	}
+
+	cbCache.On("GetQuery", config.Current.Hazelcast.Caches.CircuitBreakerCache, mock.Anything).
+		Return([]message.CircuitBreakerMessage{orphanedCB}, nil)
+
+	// Subscription doesn't exist (deleted)
+	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "orphaned-sub-id").Return((*resource.SubscriptionResource)(nil), nil)
+
+	PopulateFromCache()
+
+	// The orphaned CB gets subscriberId="unknown"
+	metrics, _ := registry.Gather()
+	for _, mf := range metrics {
+		if mf.GetName() == "golaris_open_circuit_breakers" {
+			for _, m := range mf.GetMetric() {
+				for _, label := range m.GetLabel() {
+					if label.GetName() == "subscriberId" {
+						assert.Equal(t, "unknown", label.GetValue(), "orphaned CB should get subscriberId=unknown")
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestLookupSubscriberId_ReturnsSubscriberId(t *testing.T) {
+	config.Current = test.BuildTestConfig()
+
+	subCache := new(test.SubscriptionMockCache)
+	cache.SubscriptionCache = subCache
+
+	subscription := &resource.SubscriptionResource{
+		Spec: struct {
+			Subscription resource.Subscription `json:"subscription"`
+			Environment  string                `json:"environment"`
+		}{
+			Subscription: resource.Subscription{
+				SubscriberId: "my-subscriber",
+			},
+		},
+	}
+	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "sub-123").Return(subscription, nil)
+
+	result := lookupSubscriberId("sub-123")
+	assert.Equal(t, "my-subscriber", result)
+}
+
+func TestLookupSubscriberId_ReturnsUnknownWhenNotFound(t *testing.T) {
+	config.Current = test.BuildTestConfig()
+
+	subCache := new(test.SubscriptionMockCache)
+	cache.SubscriptionCache = subCache
+
+	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "missing-sub").Return((*resource.SubscriptionResource)(nil), nil)
+
+	result := lookupSubscriberId("missing-sub")
+	assert.Equal(t, "unknown", result)
+}

--- a/internal/metrics/registry_test.go
+++ b/internal/metrics/registry_test.go
@@ -5,11 +5,13 @@
 package metrics
 
 import (
+	"fmt"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/test"
 	"testing"
 
+	"github.com/hazelcast/hazelcast-go-client/predicate"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -17,9 +19,6 @@ import (
 	"github.com/telekom/pubsub-horizon-go/message"
 	"github.com/telekom/pubsub-horizon-go/resource"
 )
-
-// Fix 2: PopulateFromCache should only load OPEN circuit breakers, not all.
-// Currently it uses predicate.True() which loads stale CLOSED entries too.
 
 func resetMetrics() {
 	registry = prometheus.NewRegistry()
@@ -48,8 +47,9 @@ func TestPopulateFromCache_OnlyOpenCircuitBreakers(t *testing.T) {
 		EventType:      "test.event.v1",
 		Environment:    "integration",
 	}
-	// After fix, PopulateFromCache uses predicate.Equal("status", "OPEN") so only open CBs are returned.
-	cbCache.On("GetQuery", config.Current.Hazelcast.Caches.CircuitBreakerCache, mock.Anything).
+	cbCache.On("GetQuery", config.Current.Hazelcast.Caches.CircuitBreakerCache, mock.MatchedBy(func(p interface{}) bool {
+		return fmt.Sprintf("%v", p) == fmt.Sprintf("%v", predicate.Equal("status", string(enum.CircuitBreakerStatusOpen)))
+	})).
 		Return([]message.CircuitBreakerMessage{openCB}, nil)
 
 	subscription := &resource.SubscriptionResource{
@@ -107,8 +107,9 @@ func TestPopulateFromCache_OrphanedCBGetsUnknownSubscriberId(t *testing.T) {
 		Environment:    "playground",
 	}
 
-	cbCache.On("GetQuery", config.Current.Hazelcast.Caches.CircuitBreakerCache, mock.Anything).
-		Return([]message.CircuitBreakerMessage{orphanedCB}, nil)
+	cbCache.On("GetQuery", config.Current.Hazelcast.Caches.CircuitBreakerCache, mock.MatchedBy(func(p interface{}) bool {
+		return fmt.Sprintf("%v", p) == fmt.Sprintf("%v", predicate.Equal("status", string(enum.CircuitBreakerStatusOpen)))
+	})).Return([]message.CircuitBreakerMessage{orphanedCB}, nil)
 
 	// Subscription doesn't exist (deleted)
 	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "orphaned-sub-id").Return((*resource.SubscriptionResource)(nil), nil)


### PR DESCRIPTION
## Summary

Fixes three related issues with circuit breaker lifecycle management discovered while investigating `"could not look up subscriberId for metric"` warnings on startup.

### 1. Orphaned circuit breaker entries on subscription delete

**Problem:** When a subscription is deleted from Kubernetes, `SubscriptionListener.OnDelete` only cleans up the `RepublishingCache` entry. The `CircuitBreakerCache` entry is left behind, accumulating as stale data in Hazelcast indefinitely.

**Fix:** `OnDelete` now also deletes the circuit breaker entry from `CircuitBreakerCache`. The existing `metrics/listener.go` `OnDelete` handler then automatically fires and removes the metric.

**File:** `internal/listener/listener.go`

### 2. Startup metric noise from stale closed circuit breakers

**Problem:** `PopulateFromCache()` uses `predicate.True()` to load **all** circuit breakers (including CLOSED orphans) into the `golaris_open_circuit_breakers` metric. This causes `"could not look up subscriberId"` warnings for every orphaned entry and pollutes the metric with `subscriberId="unknown"` time series.

**Fix:** Changed to `predicate.Equal("status", "OPEN")` so only actually open circuit breakers are loaded into the metric at startup.

**File:** `internal/metrics/registry.go`

### 3. Nil pointer panic in circuit breaker API

**Problem:** `populateCircuitBreakerResponse` dereferences `subscription.Spec` on line 129 without checking if `subscription` is nil. When querying a circuit breaker whose subscription was deleted, the API handler panics silently (empty reply, connection reset).

**Fix:** Added early return when subscription is nil or when the cache returns an error, preventing the nil pointer dereference.

**File:** `internal/api/circuitbreaker.go`

## Test plan

- [x] 3 new tests in `listener/listener_test.go` — CB deleted on subscription delete, both caches cleaned, no-op when no CB exists
- [x] 4 new tests in `metrics/registry_test.go` — only OPEN CBs loaded, orphans get "unknown", subscriberId lookup success/failure
- [x] 2 new tests in `api/circuitbreaker_test.go` — no panic on nil subscription, no panic on cache error
- [x] All existing tests pass (`go test -tags testing ./...`)