### PR TITLE
ci: pin actions to SHAs and fix Go version

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -19,12 +19,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: 1.22
+          go-version-file: go.mod
 
       - name: Run go test
         run: go test -p 1 -v ./... -coverprofile=./cover.out -covermode=atomic -coverpkg=./... -tags=testing

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -12,6 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: REUSE Compliance Check
-      uses: fsfe/reuse-action@v4
+      uses: fsfe/reuse-action@3ae3c6bdf1257ab19397fab11fd3312144692083 # v4


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full-length commit SHAs (org policy compliance)
- Replace `go-version: 1.22` with `go-version-file: go.mod`