### PR TITLE
chore(docker): update builder image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.23-alpine AS build
+FROM golang:1.26-alpine AS build
 ARG GOPROXY
 ARG GONOSUMDB
 ENV GOPROXY=$GOPROXY


### PR DESCRIPTION
This PR updates the Go version that is used as part of the multistage Docker build in the Dockerfile.