### PR TITLE
fix: resolve golangci-lint findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
       test-tags: "testing"
       test-flags: "-v -p 1"
 
+  lint:
+    uses: telekom/pubsub-horizon-ci/.github/workflows/golangci-lint.yml@main
+
   reuse:
     uses: telekom/pubsub-horizon-ci/.github/workflows/reuse-compliance.yml@main
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ name: CI
 
 on:
   push:
-  pull_request:
-    branches: [main]
 
 jobs:
   build:
@@ -23,7 +21,6 @@ jobs:
     uses: telekom/pubsub-horizon-ci/.github/workflows/reuse-compliance.yml@main
 
   publish:
-    if: github.event_name == 'push'
     needs: [build]
     uses: telekom/pubsub-horizon-ci/.github/workflows/docker-publish.yml@main
     with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,21 +143,9 @@ issues:
 
 formatters:
   enable:
-    - gci
-    - gofmt
     - gofumpt
-    - goimports
     - golines
   settings:
-    gci:
-      no-inline-comments: true
-    gofmt:
-      simplify: true
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
-        - pattern: 'a[b:len(a)]'
-          replacement: 'a[b:]'
     golines:
       max-len: 140
       tab-len: 1

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,10 +6,11 @@ package cmd
 
 import (
 	"errors"
+	"pubsub-horizon-golaris/internal/config"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"pubsub-horizon-golaris/internal/config"
 )
 
 var initCmd = &cobra.Command{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -5,7 +5,6 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"pubsub-horizon-golaris/internal/api"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
@@ -16,6 +15,8 @@ import (
 	"pubsub-horizon-golaris/internal/notify"
 	"pubsub-horizon-golaris/internal/scheduler"
 	"pubsub-horizon-golaris/internal/tracing"
+
+	"github.com/spf13/cobra"
 )
 
 var serveCmd = &cobra.Command{

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -6,17 +6,16 @@ package api
 
 import (
 	"fmt"
+	"pubsub-horizon-golaris/internal/config"
+	"pubsub-horizon-golaris/internal/metrics"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/healthcheck"
 	"github.com/gofiber/fiber/v2/middleware/pprof"
 	"github.com/rs/zerolog/log"
-	"pubsub-horizon-golaris/internal/config"
-	"pubsub-horizon-golaris/internal/metrics"
 )
 
-var (
-	app *fiber.App
-)
+var app *fiber.App
 
 func init() {
 	app = fiber.New()

--- a/internal/api/circuitbreaker.go
+++ b/internal/api/circuitbreaker.go
@@ -22,6 +22,8 @@ import (
 	"github.com/telekom/pubsub-horizon-go/message"
 )
 
+const fieldSubscriptionId = "subscriptionId"
+
 type CircuitBreakerResponse struct {
 	message.CircuitBreakerMessage
 	HealthCheck  healthcheck.HealthCheckCacheEntry `json:"healthCheck,omitempty"`
@@ -117,13 +119,13 @@ func populateCircuitBreakerResponse(res *CircuitBreakerResponse) {
 	subscription, err := cache.SubscriptionCache.Get(config.Current.Hazelcast.Caches.SubscriptionCache, res.SubscriptionId)
 	if err != nil {
 		log.Warn().Fields(map[string]any{
-			"subscriptionId": res.SubscriptionId,
+			fieldSubscriptionId: res.SubscriptionId,
 		}).Msg("could not populate circuit-breaker response with subscription data")
 		return
 	}
 	if subscription == nil {
 		log.Warn().Fields(map[string]any{
-			"subscriptionId": res.SubscriptionId,
+			fieldSubscriptionId: res.SubscriptionId,
 		}).Msg("subscription not found, skipping circuit-breaker response population")
 		return
 	}
@@ -138,7 +140,7 @@ func populateCircuitBreakerResponse(res *CircuitBreakerResponse) {
 	healthCheck, err := healthCheckCache.Get(context.Background(), healthCheckKey)
 	if err != nil {
 		log.Warn().Fields(map[string]any{
-			"subscriptionId": res.SubscriptionId,
+			fieldSubscriptionId: res.SubscriptionId,
 		}).Err(err).Msg("could not populate circuit-breaker response with healthcheck data")
 		return
 	}

--- a/internal/api/circuitbreaker.go
+++ b/internal/api/circuitbreaker.go
@@ -7,18 +7,19 @@ package api
 import (
 	"context"
 	"fmt"
-	"github.com/gofiber/fiber/v2"
-	"github.com/hazelcast/hazelcast-go-client"
-	"github.com/hazelcast/hazelcast-go-client/predicate"
-	"github.com/rs/zerolog/log"
-	"github.com/telekom/pubsub-horizon-go/enum"
-	"github.com/telekom/pubsub-horizon-go/message"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/circuitbreaker"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/healthcheck"
 	"pubsub-horizon-golaris/internal/republish"
 	"pubsub-horizon-golaris/internal/utils"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/predicate"
+	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/enum"
+	"github.com/telekom/pubsub-horizon-go/message"
 )
 
 type CircuitBreakerResponse struct {
@@ -40,7 +41,7 @@ func getAllCircuitBreakerMessages(ctx *fiber.Ctx) error {
 	}
 
 	// Build body with items wrapper
-	var body = struct {
+	body := struct {
 		Items []CircuitBreakerResponse `json:"items"`
 	}{make([]CircuitBreakerResponse, 0)}
 
@@ -63,7 +64,7 @@ func getCircuitBreakerMessageById(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).SendString("Error retrieving circuit breaker message")
 	}
 
-	//add if cbMessage is nil, then return not found status code
+	// add if cbMessage is nil, then return not found status code
 	if cbMessage == nil {
 		return ctx.Status(fiber.StatusNotFound).SendString("Circuit breaker message not found for subscription-id " + subscriptionId)
 	}
@@ -83,7 +84,7 @@ func putCloseCircuitBreakerById(ctx *fiber.Ctx) error {
 		return ctx.Status(fiber.StatusInternalServerError).SendString("Error retrieving circuit breaker message")
 	}
 
-	//add if cbMessage is nil, then return not found status code
+	// add if cbMessage is nil, then return not found status code
 	if cbMessage == nil {
 		return ctx.Status(fiber.StatusNotFound).SendString("Circuit breaker message not found for subscription-id " + subscriptionId)
 	}
@@ -107,7 +108,7 @@ func putCloseCircuitBreakerById(ctx *fiber.Ctx) error {
 }
 
 func makeCircuitBreakerResponse(cbMsg *message.CircuitBreakerMessage) CircuitBreakerResponse {
-	var resp = CircuitBreakerResponse{CircuitBreakerMessage: *cbMsg}
+	resp := CircuitBreakerResponse{CircuitBreakerMessage: *cbMsg}
 	populateCircuitBreakerResponse(&resp)
 	return resp
 }
@@ -130,9 +131,9 @@ func populateCircuitBreakerResponse(res *CircuitBreakerResponse) {
 	res.SubscriberId = subscription.Spec.Subscription.SubscriberId
 	res.PublisherId = subscription.Spec.Subscription.PublisherId
 
-	var healthCheckCache = cache.HealthCheckCache.(*hazelcast.Map)
-	var healthCheckMethod = utils.IfThenElse(subscription.Spec.Subscription.EnforceGetHealthCheck, fiber.MethodGet, fiber.MethodHead)
-	var healthCheckKey = fmt.Sprintf("%s:%s:%s", subscription.Spec.Environment, healthCheckMethod, subscription.Spec.Subscription.Callback)
+	healthCheckCache := cache.HealthCheckCache.(*hazelcast.Map)
+	healthCheckMethod := utils.IfThenElse(subscription.Spec.Subscription.EnforceGetHealthCheck, fiber.MethodGet, fiber.MethodHead)
+	healthCheckKey := fmt.Sprintf("%s:%s:%s", subscription.Spec.Environment, healthCheckMethod, subscription.Spec.Subscription.Callback)
 
 	healthCheck, err := healthCheckCache.Get(context.Background(), healthCheckKey)
 	if err != nil {

--- a/internal/api/circuitbreaker_test.go
+++ b/internal/api/circuitbreaker_test.go
@@ -5,7 +5,7 @@
 package api
 
 import (
-	"fmt"
+	"errors"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/test"
@@ -50,7 +50,7 @@ func TestMakeCircuitBreakerResponse_WithSubscriptionError(t *testing.T) {
 
 	// Subscription cache returns an error
 	subCache.On("Get", config.Current.Hazelcast.Caches.SubscriptionCache, "error-sub").
-		Return((*resource.SubscriptionResource)(nil), fmt.Errorf("hazelcast connection error"))
+		Return((*resource.SubscriptionResource)(nil), errors.New("hazelcast connection error"))
 
 	cbMsg := &message.CircuitBreakerMessage{
 		SubscriptionId: "error-sub",

--- a/internal/api/healthcheck.go
+++ b/internal/api/healthcheck.go
@@ -6,14 +6,15 @@ package api
 
 import (
 	"context"
-	"github.com/gofiber/fiber/v2"
-	"github.com/hazelcast/hazelcast-go-client"
-	"github.com/hazelcast/hazelcast-go-client/predicate"
-	"github.com/rs/zerolog/log"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/healthcheck"
 	"pubsub-horizon-golaris/internal/utils"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/hazelcast/hazelcast-go-client"
+	"github.com/hazelcast/hazelcast-go-client/predicate"
+	"github.com/rs/zerolog/log"
 )
 
 type HealthCheckResponse struct {
@@ -22,14 +23,14 @@ type HealthCheckResponse struct {
 }
 
 func getAllHealthChecks(ctx *fiber.Ctx) error {
-	var healthStateCache = cache.HealthCheckCache.(*hazelcast.Map)
+	healthStateCache := cache.HealthCheckCache.(*hazelcast.Map)
 
 	values, err := healthStateCache.GetValues(context.Background())
 	if err != nil {
 		return err
 	}
 
-	var body = struct {
+	body := struct {
 		Items []HealthCheckResponse `json:"items"`
 	}{make([]HealthCheckResponse, 0)}
 
@@ -42,7 +43,7 @@ func getAllHealthChecks(ctx *fiber.Ctx) error {
 }
 
 func makeResponse(healthCheck *healthcheck.HealthCheckCacheEntry) HealthCheckResponse {
-	var res = HealthCheckResponse{HealthCheckCacheEntry: *healthCheck}
+	res := HealthCheckResponse{HealthCheckCacheEntry: *healthCheck}
 	populateHealthCheckResponse(&res)
 	return res
 }
@@ -58,7 +59,7 @@ func populateHealthCheckResponse(res *HealthCheckResponse) {
 	}
 
 	for _, subscription := range subscriptions {
-		var enforceGetRequest = utils.IfThenElse(res.Method == fiber.MethodGet, true, false)
+		enforceGetRequest := utils.IfThenElse(res.Method == fiber.MethodGet, true, false)
 		if enforceGetRequest == subscription.Spec.Subscription.EnforceGetHealthCheck {
 			res.SubscriptionIds = append(res.SubscriptionIds, subscription.Spec.Subscription.SubscriptionId)
 		}

--- a/internal/api/republishing.go
+++ b/internal/api/republishing.go
@@ -6,19 +6,20 @@ package api
 
 import (
 	"context"
+	"pubsub-horizon-golaris/internal/cache"
+	"pubsub-horizon-golaris/internal/republish"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/rs/zerolog/log"
-	"pubsub-horizon-golaris/internal/cache"
-	"pubsub-horizon-golaris/internal/republish"
 )
 
 func getRepublishingEntries(ctx *fiber.Ctx) error {
-	var body = struct {
+	body := struct {
 		Items []republish.RepublishingCacheEntry `json:"items"`
 	}{make([]republish.RepublishingCacheEntry, 0)}
 
-	var republishingCache = cache.RepublishingCache.(*hazelcast.Map)
+	republishingCache := cache.RepublishingCache.(*hazelcast.Map)
 	values, err := republishingCache.GetValues(context.Background())
 	if err != nil {
 		log.Error().Err(err).Msg("Could not retrieve republishing cache entries")

--- a/internal/auth/token.go
+++ b/internal/auth/token.go
@@ -6,19 +6,21 @@ package auth
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/rs/zerolog/log"
 	"net/http"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 var Client = &http.Client{Timeout: 30 * time.Second}
 
-func RetrieveToken(url string, clientId string, clientSecret string) (string, error) {
-	requestBody := bytes.NewBuffer([]byte("grant_type=client_credentials"))
+func RetrieveToken(url, clientId, clientSecret string) (string, error) {
+	requestBody := bytes.NewBufferString("grant_type=client_credentials")
 
-	request, err := http.NewRequest(http.MethodPost, url, requestBody)
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, requestBody)
 	if err != nil {
 		return "", err
 	}

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -5,11 +5,12 @@
 package auth
 
 import (
-	"github.com/jarcoal/httpmock"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -20,7 +21,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestRetrieveToken_Success(t *testing.T) {
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -33,11 +34,10 @@ func TestRetrieveToken_Success(t *testing.T) {
 
 	assertions.NoError(err)
 	assertions.NotNil(token)
-
 }
 
 func TestRetrieveToken_RequestError(t *testing.T) {
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -24,7 +24,7 @@ import (
 
 type HazelcastMapInterface interface {
 	Get(ctx context.Context, key interface{}) (interface{}, error)
-	Set(ctx context.Context, key interface{}, value interface{}) error
+	Set(ctx context.Context, key, value interface{}) error
 	TryLockWithTimeout(ctx context.Context, key interface{}, timeout time.Duration) (bool, error)
 	GetEntrySet(ctx context.Context) ([]types.Entry, error)
 	NewLockContext(ctx context.Context) context.Context
@@ -35,22 +35,28 @@ type HazelcastMapInterface interface {
 	ContainsKey(ctx context.Context, key interface{}) (bool, error)
 	Clear(ctx context.Context) error
 	Lock(ctx context.Context, key interface{}) error
-	TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease time.Duration, timeout time.Duration) (bool, error)
+	TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease, timeout time.Duration) (bool, error)
 	TryLockWithLease(ctx context.Context, key interface{}, lease time.Duration) (bool, error)
 }
 
-var SubscriptionCache c.HazelcastBasedCache[resource.SubscriptionResource]
-var CircuitBreakerCache c.HazelcastBasedCache[message.CircuitBreakerMessage]
-var HealthCheckCache HazelcastMapInterface
-var RepublishingCache HazelcastMapInterface
-var hazelcastClient *hazelcast.Client
+var (
+	SubscriptionCache   c.HazelcastBasedCache[resource.SubscriptionResource]
+	CircuitBreakerCache c.HazelcastBasedCache[message.CircuitBreakerMessage]
+	HealthCheckCache    HazelcastMapInterface
+	RepublishingCache   HazelcastMapInterface
+	hazelcastClient     *hazelcast.Client
+)
 
-var HandlerCache HazelcastMapInterface
-var NotificationSender HazelcastMapInterface
+var (
+	HandlerCache       HazelcastMapInterface
+	NotificationSender HazelcastMapInterface
+)
 
-var DeliveringLockKey string
-var FailedLockKey string
-var WaitingLockKey string
+var (
+	DeliveringLockKey string
+	FailedLockKey     string
+	WaitingLockKey    string
+)
 
 func Initialize() {
 	c := createNewHazelcastConfig()
@@ -80,7 +86,7 @@ func createNewHazelcastConfig() hazelcast.Config {
 }
 
 func parseHazelcastLogLevel(logLevel string) zerolog.Level {
-	var hazelcastLogLevel, err = zerolog.ParseLevel(logLevel)
+	hazelcastLogLevel, err := zerolog.ParseLevel(logLevel)
 	if err != nil {
 		log.Error().Err(err).Fields(map[string]any{
 			"logLevel": config.Current.Hazelcast.LogLevel,
@@ -96,7 +102,7 @@ func initializeCaches(hzConfig hazelcast.Config) error {
 
 	hazelcastClient, err = hazelcast.StartNewClientWithConfig(context.Background(), hzConfig)
 	if err != nil {
-		return fmt.Errorf("error initializing Hazelcast client: %v", err)
+		return fmt.Errorf("error initializing Hazelcast client: %w", err)
 	}
 
 	SubscriptionCache = c.NewHazelcastCacheWithClient[resource.SubscriptionResource](hazelcastClient)
@@ -104,17 +110,17 @@ func initializeCaches(hzConfig hazelcast.Config) error {
 
 	HealthCheckCache, err = hazelcastClient.GetMap(context.Background(), config.Current.Hazelcast.Caches.HealthCheckCache)
 	if err != nil {
-		return fmt.Errorf("error initializing HealthCheckCache: %v", err)
+		return fmt.Errorf("error initializing HealthCheckCache: %w", err)
 	}
 
 	RepublishingCache, err = hazelcastClient.GetMap(context.Background(), config.Current.Hazelcast.Caches.RepublishingCache)
 	if err != nil {
-		return fmt.Errorf("error initializing RepublishingCache: %v", err)
+		return fmt.Errorf("error initializing RepublishingCache: %w", err)
 	}
 
 	HandlerCache, err = hazelcastClient.GetMap(context.Background(), config.Current.Hazelcast.Caches.HandlerCache)
 	if err != nil {
-		return fmt.Errorf("error initializing DeliveringHandler: %v", err)
+		return fmt.Errorf("error initializing DeliveringHandler: %w", err)
 	}
 
 	NotificationSender, err = hazelcastClient.GetMap(context.Background(), "notificationSender")

--- a/internal/circuitbreaker/circuitbreaker.go
+++ b/internal/circuitbreaker/circuitbreaker.go
@@ -63,69 +63,97 @@ func HandleOpenCircuitBreaker(cbMessage message.CircuitBreakerMessage, subscript
 		return
 	}
 
-	// Check if circuit breaker is in cool down
-	if !healthcheck.IsHealthCheckInCoolDown(hcData.HealthCheckEntry) {
-		// Perform health check and update health check data
-		err := healthCheckFunc(hcData, subscription)
-		if err != nil {
-			log.Debug().Msgf("HealthCheck failed for key %s", hcData.HealthCheckKey)
-
-			// I have observed the case where events were set to DELIVERING.
-			// Then the DeliveryType was changed to SSE. However, the events landed on WAITING.
-			// HealthCheck was performed, but the CallbackUrl was already missing because deliveryType was set to SSE.
-			if subscription.Spec.Subscription.Callback == "" || subscription.Spec.Subscription.DeliveryType == "sse" ||
-				subscription.Spec.Subscription.DeliveryType == "server_sent_event" {
-
-				republishingCacheEntry := republish.RepublishingCacheEntry{
-					SubscriptionId:   subscription.Spec.Subscription.SubscriptionId,
-					RepublishingUpTo: time.Now(),
-					PostponedUntil:   time.Now(),
-				}
-				if err := SetNewRepublishingCacheEntry(hcData.Ctx, republishingCacheEntry, cbMessage.SubscriptionId, true); err != nil {
-					log.Error().Err(err).Msgf("Error while creating RepublishingCacheEntry entry for subscriptionId %s", cbMessage.SubscriptionId)
-					return
-				}
-				CloseCircuitBreaker(&cbMessage)
-			}
-			return
-		}
-	} else {
-		log.Debug().Msgf("HealthCheck is in cooldown for key %s", hcData.HealthCheckKey)
+	if !performHealthCheckIfReady(hcData, &cbMessage, subscription) {
+		return
 	}
 
 	// Create republishing cache entry if last health check was successful
 	if slices.Contains(config.Current.HealthCheck.SuccessfulResponseCodes, hcData.HealthCheckEntry.LastCheckedStatus) {
-		// Check if circuit breaker is in a loop and update loop counter of cb message or reset it
-		err = checkForCircuitBreakerLoop(&cbMessage)
-		if err != nil {
-			log.Error().Err(err).Msgf("Error handling circuit breaker loop for subscriptionId %s", cbMessage.SubscriptionId)
-		}
-
-		// Calculate exponential backoff for new republishing cache entry based on updated circuit breaker loop counter
-		exponentialBackoff := calculateExponentialBackoff(cbMessage)
-		log.Debug().
-			Msgf("Calculated exponential backoff for circuit breaker with subscriptionId %s: %v", cbMessage.SubscriptionId, exponentialBackoff)
-
-		// Create republishing cache entry
-		republishingCacheEntry := republish.RepublishingCacheEntry{
-			SubscriptionId:   cbMessage.SubscriptionId,
-			RepublishingUpTo: time.Now(),
-			PostponedUntil:   time.Now().Add(+exponentialBackoff),
-		}
-		log.Debug().
-			Msgf("postponedUntil for subscriptionId %s set to %v", republishingCacheEntry.SubscriptionId, republishingCacheEntry.PostponedUntil)
-
-		if err := SetNewRepublishingCacheEntry(hcData.Ctx, republishingCacheEntry, cbMessage.SubscriptionId, true); err != nil {
-			log.Error().Err(err).Msgf("Error while creating RepublishingCacheEntry entry for subscriptionId %s", cbMessage.SubscriptionId)
+		if err := createRepublishingWithBackoff(hcData.Ctx, &cbMessage); err != nil {
 			return
 		}
-
-		log.Debug().
-			Msgf("Successfully created RepublishingCacheEntry entry for subscriptionId %s: %+v", cbMessage.SubscriptionId, republishingCacheEntry)
-		CloseCircuitBreaker(&cbMessage)
 	}
 
 	log.Debug().Msgf("Successfully processed open CircuitBreaker entry for subscriptionId %s", cbMessage.SubscriptionId)
+}
+
+// performHealthCheckIfReady executes the health check if not in cooldown and handles the
+// case where a subscription has switched to SSE delivery while events were in DELIVERING state.
+// Returns true if processing should continue, false if the function should return early.
+func performHealthCheckIfReady(
+	hcData *healthcheck.PreparedHealthCheckData,
+	cbMessage *message.CircuitBreakerMessage,
+	subscription *resource.SubscriptionResource,
+) bool {
+	if healthcheck.IsHealthCheckInCoolDown(hcData.HealthCheckEntry) {
+		log.Debug().Msgf("HealthCheck is in cooldown for key %s", hcData.HealthCheckKey)
+		return true
+	}
+
+	err := healthCheckFunc(hcData, subscription)
+	if err == nil {
+		return true
+	}
+
+	log.Debug().Msgf("HealthCheck failed for key %s", hcData.HealthCheckKey)
+
+	// I have observed the case where events were set to DELIVERING.
+	// Then the DeliveryType was changed to SSE. However, the events landed on WAITING.
+	// HealthCheck was performed, but the CallbackUrl was already missing because deliveryType was set to SSE.
+	if isSubscriptionNonCallback(subscription) {
+		republishingCacheEntry := republish.RepublishingCacheEntry{
+			SubscriptionId:   subscription.Spec.Subscription.SubscriptionId,
+			RepublishingUpTo: time.Now(),
+			PostponedUntil:   time.Now(),
+		}
+		if err := SetNewRepublishingCacheEntry(hcData.Ctx, republishingCacheEntry, cbMessage.SubscriptionId, true); err != nil {
+			log.Error().Err(err).Msgf("Error while creating RepublishingCacheEntry entry for subscriptionId %s", cbMessage.SubscriptionId)
+			return false
+		}
+		CloseCircuitBreaker(cbMessage)
+	}
+	return false
+}
+
+// isSubscriptionNonCallback returns true if the subscription has no callback URL or uses SSE delivery.
+func isSubscriptionNonCallback(subscription *resource.SubscriptionResource) bool {
+	return subscription.Spec.Subscription.Callback == "" ||
+		subscription.Spec.Subscription.DeliveryType == "sse" ||
+		subscription.Spec.Subscription.DeliveryType == "server_sent_event"
+}
+
+// createRepublishingWithBackoff handles loop detection, exponential backoff calculation,
+// and creation of the republishing cache entry for a successful health check scenario.
+func createRepublishingWithBackoff(ctx context.Context, cbMessage *message.CircuitBreakerMessage) error {
+	// Check if circuit breaker is in a loop and update loop counter of cb message or reset it
+	err := checkForCircuitBreakerLoop(cbMessage)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error handling circuit breaker loop for subscriptionId %s", cbMessage.SubscriptionId)
+	}
+
+	// Calculate exponential backoff for new republishing cache entry based on updated circuit breaker loop counter
+	exponentialBackoff := calculateExponentialBackoff(*cbMessage)
+	log.Debug().
+		Msgf("Calculated exponential backoff for circuit breaker with subscriptionId %s: %v", cbMessage.SubscriptionId, exponentialBackoff)
+
+	// Create republishing cache entry
+	republishingCacheEntry := republish.RepublishingCacheEntry{
+		SubscriptionId:   cbMessage.SubscriptionId,
+		RepublishingUpTo: time.Now(),
+		PostponedUntil:   time.Now().Add(+exponentialBackoff),
+	}
+	log.Debug().
+		Msgf("postponedUntil for subscriptionId %s set to %v", republishingCacheEntry.SubscriptionId, republishingCacheEntry.PostponedUntil)
+
+	if err := SetNewRepublishingCacheEntry(ctx, republishingCacheEntry, cbMessage.SubscriptionId, true); err != nil {
+		log.Error().Err(err).Msgf("Error while creating RepublishingCacheEntry entry for subscriptionId %s", cbMessage.SubscriptionId)
+		return err
+	}
+
+	log.Debug().
+		Msgf("Successfully created RepublishingCacheEntry entry for subscriptionId %s: %+v", cbMessage.SubscriptionId, republishingCacheEntry)
+	CloseCircuitBreaker(cbMessage)
+	return nil
 }
 
 // checkForCircuitBreakerLoop evaluates the circuit breaker's last opened timestamp against the configured loop detection period.

--- a/internal/circuitbreaker/circuitbreaker.go
+++ b/internal/circuitbreaker/circuitbreaker.go
@@ -21,25 +21,27 @@ import (
 	"github.com/telekom/pubsub-horizon-go/types"
 )
 
-var (
-	healthCheckFunc = healthcheck.CheckConsumerHealth
-)
+var healthCheckFunc = healthcheck.CheckConsumerHealth
 
 // HandleOpenCircuitBreaker handles the process when a circuit breaker is open.
 // The function takes two parameters:
 // - cbMessage: a CircuitBreakerMessage instance containing the details of the circuit breaker.
 // - subscription: a pointer to a SubscriptionResource instance.
-// The function performs several operations including specifying the HTTP method based on the subscription configuration,
-// retrieving and updating health check data, performing a health check if not in cool down, and creating a republishing cache entry if the last health check was successful.
-// It also handles the process of closing the circuit breaker once all operations are successfully completed.
+// The function performs several operations including specifying the HTTP method based on the
+// subscription configuration, retrieving and updating health check data, performing a health
+// check if not in cool down, and creating a republishing cache entry if the last health check
+// was successful. It also handles the process of closing the circuit breaker once all
+// operations are successfully completed.
 func HandleOpenCircuitBreaker(cbMessage message.CircuitBreakerMessage, subscription *resource.SubscriptionResource) {
 	hcData, err := healthcheck.PrepareHealthCheck(subscription)
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to create new HealthCheckCacheEntry for subscriptionId %s", subscription.Spec.Subscription.SubscriptionId)
+		log.Error().
+			Err(err).
+			Msgf("Failed to create new HealthCheckCacheEntry for subscriptionId %s", subscription.Spec.Subscription.SubscriptionId)
 		return
 	}
 
-	if hcData.IsAcquired == false {
+	if !hcData.IsAcquired {
 		log.Debug().Msgf("Could not acquire lock for HealthCheckCacheEntry, skipping entry for subscriptionId %s", hcData.HealthCheckKey)
 		return
 	}
@@ -47,7 +49,7 @@ func HandleOpenCircuitBreaker(cbMessage message.CircuitBreakerMessage, subscript
 
 	// Ensure that the lock is released when the function is ended
 	defer func() {
-		if hcData.IsAcquired == true {
+		if hcData.IsAcquired {
 			if err := cache.HealthCheckCache.Unlock(hcData.Ctx, hcData.HealthCheckKey); err != nil {
 				log.Error().Err(err).Msgf("Error unlocking HealthCheckCacheEntry with key %s", hcData.HealthCheckKey)
 			}
@@ -62,7 +64,7 @@ func HandleOpenCircuitBreaker(cbMessage message.CircuitBreakerMessage, subscript
 	}
 
 	// Check if circuit breaker is in cool down
-	if healthcheck.IsHealthCheckInCoolDown(hcData.HealthCheckEntry) == false {
+	if !healthcheck.IsHealthCheckInCoolDown(hcData.HealthCheckEntry) {
 		// Perform health check and update health check data
 		err := healthCheckFunc(hcData, subscription)
 		if err != nil {
@@ -71,8 +73,14 @@ func HandleOpenCircuitBreaker(cbMessage message.CircuitBreakerMessage, subscript
 			// I have observed the case where events were set to DELIVERING.
 			// Then the DeliveryType was changed to SSE. However, the events landed on WAITING.
 			// HealthCheck was performed, but the CallbackUrl was already missing because deliveryType was set to SSE.
-			if subscription.Spec.Subscription.Callback == "" || subscription.Spec.Subscription.DeliveryType == "sse" || subscription.Spec.Subscription.DeliveryType == "server_sent_event" {
-				republishingCacheEntry := republish.RepublishingCacheEntry{SubscriptionId: subscription.Spec.Subscription.SubscriptionId, RepublishingUpTo: time.Now(), PostponedUntil: time.Now()}
+			if subscription.Spec.Subscription.Callback == "" || subscription.Spec.Subscription.DeliveryType == "sse" ||
+				subscription.Spec.Subscription.DeliveryType == "server_sent_event" {
+
+				republishingCacheEntry := republish.RepublishingCacheEntry{
+					SubscriptionId:   subscription.Spec.Subscription.SubscriptionId,
+					RepublishingUpTo: time.Now(),
+					PostponedUntil:   time.Now(),
+				}
 				if err := SetNewRepublishingCacheEntry(hcData.Ctx, republishingCacheEntry, cbMessage.SubscriptionId, true); err != nil {
 					log.Error().Err(err).Msgf("Error while creating RepublishingCacheEntry entry for subscriptionId %s", cbMessage.SubscriptionId)
 					return
@@ -95,18 +103,25 @@ func HandleOpenCircuitBreaker(cbMessage message.CircuitBreakerMessage, subscript
 
 		// Calculate exponential backoff for new republishing cache entry based on updated circuit breaker loop counter
 		exponentialBackoff := calculateExponentialBackoff(cbMessage)
-		log.Debug().Msgf("Calculated exponential backoff for circuit breaker with subscriptionId %s: %v", cbMessage.SubscriptionId, exponentialBackoff)
+		log.Debug().
+			Msgf("Calculated exponential backoff for circuit breaker with subscriptionId %s: %v", cbMessage.SubscriptionId, exponentialBackoff)
 
 		// Create republishing cache entry
-		republishingCacheEntry := republish.RepublishingCacheEntry{SubscriptionId: cbMessage.SubscriptionId, RepublishingUpTo: time.Now(), PostponedUntil: time.Now().Add(+exponentialBackoff)}
-		log.Debug().Msgf("postponedUntil for subscriptionId %s set to %v", republishingCacheEntry.SubscriptionId, republishingCacheEntry.PostponedUntil)
+		republishingCacheEntry := republish.RepublishingCacheEntry{
+			SubscriptionId:   cbMessage.SubscriptionId,
+			RepublishingUpTo: time.Now(),
+			PostponedUntil:   time.Now().Add(+exponentialBackoff),
+		}
+		log.Debug().
+			Msgf("postponedUntil for subscriptionId %s set to %v", republishingCacheEntry.SubscriptionId, republishingCacheEntry.PostponedUntil)
 
 		if err := SetNewRepublishingCacheEntry(hcData.Ctx, republishingCacheEntry, cbMessage.SubscriptionId, true); err != nil {
 			log.Error().Err(err).Msgf("Error while creating RepublishingCacheEntry entry for subscriptionId %s", cbMessage.SubscriptionId)
 			return
 		}
 
-		log.Debug().Msgf("Successfully created RepublishingCacheEntry entry for subscriptionId %s: %+v", cbMessage.SubscriptionId, republishingCacheEntry)
+		log.Debug().
+			Msgf("Successfully created RepublishingCacheEntry entry for subscriptionId %s: %+v", cbMessage.SubscriptionId, republishingCacheEntry)
 		CloseCircuitBreaker(&cbMessage)
 	}
 
@@ -124,11 +139,17 @@ func checkForCircuitBreakerLoop(cbMessage *message.CircuitBreakerMessage) error 
 	// If circuit breaker last opened timestamp is within loop detection period, increase loop counter
 	if cbMessage.LastOpened != nil && time.Since(cbMessage.LastOpened.ToTime()).Seconds() < loopDetectionPeriod.Seconds() {
 		cbMessage.LoopCounter++
-		log.Debug().Msgf("Circuit breaker opened within loop detection period. Increased loop counter for subscription %s: %d", cbMessage.SubscriptionId, cbMessage.LoopCounter)
+		log.Debug().
+			Msgf("Circuit breaker opened within loop detection period. "+
+				"Increased loop counter for subscription %s: %d",
+				cbMessage.SubscriptionId, cbMessage.LoopCounter)
 	} else {
 		// If outside the loop detection period, reset loop  counter
 		cbMessage.LoopCounter = 0
-		log.Debug().Msgf("Circuit breaker opened outside loop detection period. Reseted loop counter for subscription %s: %v", cbMessage.SubscriptionId, cbMessage.LoopCounter)
+		log.Debug().
+			Msgf("Circuit breaker opened outside loop detection period. "+
+				"Reseted loop counter for subscription %s: %v",
+				cbMessage.SubscriptionId, cbMessage.LoopCounter)
 	}
 	// set last opened for the next loop detection
 	cbMessage.LastOpened = cbMessage.LastModified
@@ -136,7 +157,9 @@ func checkForCircuitBreakerLoop(cbMessage *message.CircuitBreakerMessage) error 
 
 	err := cache.CircuitBreakerCache.Put(config.Current.Hazelcast.Caches.CircuitBreakerCache, cbMessage.SubscriptionId, *cbMessage)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error while updating CircuitBreaker for subscription %s with loop detection result: %v", cbMessage.SubscriptionId, err)
+		log.Error().
+			Err(err).
+			Msgf("Error while updating CircuitBreaker for subscription %s with loop detection result: %v", cbMessage.SubscriptionId, err)
 		return err
 	}
 
@@ -146,7 +169,12 @@ func checkForCircuitBreakerLoop(cbMessage *message.CircuitBreakerMessage) error 
 // SetNewRepublishingCacheEntry creates a new republishing cache entry for the given subscriptionId.
 // It first attempts to delete any existing republishing entry for the subscriptionId and then sets
 // the new republishing entry in the cache.
-func SetNewRepublishingCacheEntry(ctx context.Context, republishingEntry republish.RepublishingCacheEntry, subscriptionId string, forceDelete bool) error {
+func SetNewRepublishingCacheEntry(
+	ctx context.Context,
+	republishingEntry republish.RepublishingCacheEntry,
+	subscriptionId string,
+	forceDelete bool,
+) error {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
 
@@ -230,7 +258,11 @@ func calculateExponentialBackoff(cbMessage message.CircuitBreakerMessage) time.D
 		exponentialBackoff = exponentialBackoffMax
 	}
 
-	log.Debug().Msgf("Calculating exponential backoff, subscriptionId %s, loopCounter %d, exponentialBackoffBase %v, exponentialBackoffMax %v, exponentialBackoff %v", cbMessage.SubscriptionId, cbMessage.LoopCounter, exponentialBackoffBase, exponentialBackoffMax, exponentialBackoff)
+	log.Debug().
+		Msgf("Calculating exponential backoff, subscriptionId %s, loopCounter %d, "+
+			"exponentialBackoffBase %v, exponentialBackoffMax %v, exponentialBackoff %v",
+			cbMessage.SubscriptionId, cbMessage.LoopCounter,
+			exponentialBackoffBase, exponentialBackoffMax, exponentialBackoff)
 
 	return exponentialBackoff
 }

--- a/internal/circuitbreaker/circuitbreaker_test.go
+++ b/internal/circuitbreaker/circuitbreaker_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 
 func TestHandleOpenCircuitBreaker_SuccessWithoutHealthCheckEntry(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -78,7 +78,7 @@ func TestHandleOpenCircuitBreaker_SuccessWithoutHealthCheckEntry(t *testing.T) {
 
 func TestHandleOpenCircuitBreaker_SuccessWithExistingHealthCheckEntry(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -93,7 +93,8 @@ func TestHandleOpenCircuitBreaker_SuccessWithExistingHealthCheckEntry(t *testing
 	// Create  health check entry that  provokes a cool down and no republishing because of lst http status
 	hcData, _ := healthcheck.PrepareHealthCheck(testSubscriptionResource)
 	cache.HealthCheckCache.Unlock(hcData.Ctx, testHealthCheckKey)
-	hcData.HealthCheckEntry.LastChecked = time.Now().Add(-time.Duration(config.Current.HealthCheck.CoolDownTime.Seconds() * float64(time.Second)))
+	hcData.HealthCheckEntry.LastChecked = time.Now().
+		Add(-time.Duration(config.Current.HealthCheck.CoolDownTime.Seconds() * float64(time.Second)))
 	cache.HealthCheckCache.Set(context.Background(), testHealthCheckKey, hcData.HealthCheckEntry)
 
 	// Mock health check function
@@ -123,7 +124,7 @@ func TestHandleOpenCircuitBreaker_SuccessWithExistingHealthCheckEntry(t *testing
 
 func TestHandleOpenCircuitBreaker_WithConsumerUnhealthy(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -162,7 +163,7 @@ func TestHandleOpenCircuitBreaker_WithConsumerUnhealthy(t *testing.T) {
 
 func TestHandleOpenCircuitBreaker_HealthCheckEntryAlreadyLocked(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -195,13 +196,13 @@ func TestHandleOpenCircuitBreaker_HealthCheckEntryAlreadyLocked(t *testing.T) {
 	healthCheckCacheLocked, _ := cache.HealthCheckCache.IsLocked(hcData.Ctx, testHealthCheckKey)
 	assertions.True(healthCheckCacheLocked)
 
-	//Cleanup
+	// Cleanup
 	defer cache.HealthCheckCache.Unlock(hcData.Ctx, testHealthCheckKey)
 }
 
 func TestHandleOpenCircuitBreaker_CoolDownWithoutRepublishing(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -241,7 +242,7 @@ func TestHandleOpenCircuitBreaker_CoolDownWithoutRepublishing(t *testing.T) {
 
 func TestHandleOpenCircuitBreaker_CoolDownWithRepublishing(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -281,7 +282,7 @@ func TestHandleOpenCircuitBreaker_CoolDownWithRepublishing(t *testing.T) {
 
 func TestHandleOpenCircuitBreaker_IncreaseLoopCounterWithinLoopDetectionPeriod(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	config.Current.CircuitBreaker.OpenLoopDetectionPeriod = 300 * time.Second
 
@@ -321,7 +322,7 @@ func TestHandleOpenCircuitBreaker_IncreaseLoopCounterWithinLoopDetectionPeriod(t
 
 func TestHandleOpenCircuitBreaker_ResetLoopCounterOutsideLoopDetectionPeriod(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	config.Current.CircuitBreaker.OpenLoopDetectionPeriod = 0 * time.Second
 
@@ -357,7 +358,7 @@ func TestHandleOpenCircuitBreaker_ResetLoopCounterOutsideLoopDetectionPeriod(t *
 
 func TestHandleOpenCircuitBreaker_UnchangedLoopCounterWhenUnhealthy(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	config.Current.CircuitBreaker.OpenLoopDetectionPeriod = 600 * time.Second
 
@@ -393,7 +394,7 @@ func TestHandleOpenCircuitBreaker_UnchangedLoopCounterWhenUnhealthy(t *testing.T
 
 func TestHandleOpenCircuitBreaker_RepublishingPostponedDueToBackoff(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	config.Current.CircuitBreaker.OpenLoopDetectionPeriod = 600 * time.Second
 
@@ -429,7 +430,7 @@ func TestHandleOpenCircuitBreaker_RepublishingPostponedDueToBackoff(t *testing.T
 
 func TestForceDeleteRepublishingEntry_WithoutEntryToDelete(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -438,9 +439,9 @@ func TestForceDeleteRepublishingEntry_WithoutEntryToDelete(t *testing.T) {
 
 	testCbMessage := test.NewTestCbMessage(testSubscriptionId)
 	testSubscriptionResource := test.NewTestSubscriptionResource(testSubscriptionId, testCallbackUrl, testEnvironment)
-	preparedHealthCheck, err := healthcheck.PrepareHealthCheck(testSubscriptionResource)
+	preparedHealthCheck, _ := healthcheck.PrepareHealthCheck(testSubscriptionResource)
 
-	err = forceDeleteRepublishingEntry(preparedHealthCheck.Ctx, testCbMessage.SubscriptionId)
+	err := forceDeleteRepublishingEntry(preparedHealthCheck.Ctx, testCbMessage.SubscriptionId)
 
 	// assert the result
 	assertions.NoError(err)
@@ -448,7 +449,7 @@ func TestForceDeleteRepublishingEntry_WithoutEntryToDelete(t *testing.T) {
 
 func TestForceDeleteRepublishingEntry_WithEntryToDelete(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -461,12 +462,12 @@ func TestForceDeleteRepublishingEntry_WithEntryToDelete(t *testing.T) {
 	testSubscriptionResource := test.NewTestSubscriptionResource(testSubscriptionId, testCallbackUrl, testEnvironment)
 
 	republishingCacheEntry := republish.RepublishingCacheEntry{SubscriptionId: testCbMessage.SubscriptionId, RepublishingUpTo: time.Now()}
-	err := cache.RepublishingCache.Set(context.Background(), testCbMessage.SubscriptionId, republishingCacheEntry)
+	_ = cache.RepublishingCache.Set(context.Background(), testCbMessage.SubscriptionId, republishingCacheEntry)
 
-	preparedHealthCheck, err := healthcheck.PrepareHealthCheck(testSubscriptionResource)
+	preparedHealthCheck, _ := healthcheck.PrepareHealthCheck(testSubscriptionResource)
 
 	// call the function under test
-	err = forceDeleteRepublishingEntry(preparedHealthCheck.Ctx, testCbMessage.SubscriptionId)
+	err := forceDeleteRepublishingEntry(preparedHealthCheck.Ctx, testCbMessage.SubscriptionId)
 
 	// assert the result
 	assertions.NoError(err)
@@ -475,7 +476,7 @@ func TestForceDeleteRepublishingEntry_WithEntryToDelete(t *testing.T) {
 
 func TestCloseCircuitBreaker(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -509,7 +510,6 @@ func TestCheckForCircuitBreakerLoop_WithinLoopDetectionPeriod(t *testing.T) {
 	assert.Equal(t, 1, testCbMessage.LoopCounter, "LoopCounter should be incremented")
 	assert.True(t, testCbMessage.LastModified.ToTime().After(initialLastModified), "LastOpened should be updated to LastModified")
 	assert.Equal(t, testCbMessage.LastOpened, types.NewTimestamp(initialLastModified), "LastModified should be updated afterwards")
-
 }
 
 func TestCheckForCircuitBreakerLoop_OutsideLoopDetectionPeriod(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,62 +39,84 @@ func configureViper() {
 }
 
 func setDefaults() {
-	// General
 	viper.SetDefault("logLevel", "info")
 	viper.SetDefault("port", 8080)
 
-	// Processes
+	setCircuitBreakerDefaults()
+	setHealthCheckDefaults()
+	setRepublishingDefaults()
+	setHazelcastDefaults()
+	setKafkaDefaults()
+	setMetricsDefaults()
+	setMongoDefaults()
+	setSecurityDefaults()
+	setTracingDefaults()
+	setHandlerDefaults()
+	setNotificationDefaults()
+}
+
+func setCircuitBreakerDefaults() {
 	viper.SetDefault("circuitBreaker.openCheckInterval", "30s")
 	viper.SetDefault("circuitBreaker.openLoopDetectionPeriod", "75m")
 	viper.SetDefault("circuitBreaker.exponentialBackoffBase", "1000ms")
 	viper.SetDefault("circuitBreaker.exponentialBackoffMax", "60m")
+}
 
+func setHealthCheckDefaults() {
 	viper.SetDefault("healthCheck.successfulResponseCodes", []int{200, 201, 202, 204})
 	viper.SetDefault("healthCheck.coolDownTime", "30s")
+}
 
+func setRepublishingDefaults() {
 	viper.SetDefault("republishing.checkInterval", "30s")
 	viper.SetDefault("republishing.initialDelay", "3s")
 	viper.SetDefault("republishing.batchSize", 10)
 	viper.SetDefault("republishing.throttlingIntervalTime", "1s")
 	viper.SetDefault("republishing.deliveringStatesOffset", "70m")
+}
 
-	// Caches
+func setHazelcastDefaults() {
 	viper.SetDefault("hazelcast.caches.subscriptionCache", "subscriptions.subscriber.horizon.telekom.de.v1")
 	viper.SetDefault("hazelcast.caches.circuitBreakerCache", "circuit-breakers")
 	viper.SetDefault("hazelcast.caches.healthCheckCache", "health-check-cache")
 	viper.SetDefault("hazelcast.caches.republishingCache", "republishing-cache")
 	viper.SetDefault("hazelcast.caches.handlerCache", "handler-cache")
 
-	// Hazelcast
 	viper.SetDefault("hazelcast.clusterName", "dev")
 	viper.SetDefault("hazelcast.serviceDNS", "localhost:5701")
 	viper.SetDefault("hazelcast.logLevel", "info")
+}
 
-	// Kafka
+func setKafkaDefaults() {
 	viper.SetDefault("kafka.brokers", "localhost:9092")
 	viper.SetDefault("kafka.topics", []string{"status"})
+}
 
-	// Metrics
+func setMetricsDefaults() {
 	viper.SetDefault("metrics.enabled", true)
+}
 
-	// Mongo
+func setMongoDefaults() {
 	viper.SetDefault("mongo.url", "mongodb://localhost:27017")
 	viper.SetDefault("mongo.database", "horizon")
 	viper.SetDefault("mongo.collection", "status")
 	viper.SetDefault("mongo.bulkSize", 50)
+}
 
-	// Security
+func setSecurityDefaults() {
 	viper.SetDefault("security.enabled", true)
 	viper.SetDefault("security.url", "iris")
 	viper.SetDefault("security.clientId", "clientId")
 	viper.SetDefault("security.clientSecret", []string{"realm=clientSecret"})
+}
 
-	// Tracing
+func setTracingDefaults() {
 	viper.SetDefault("tracing.enabled", true)
 	viper.SetDefault("tracing.collectorEndpoint", "http://localhost:4318")
 	viper.SetDefault("tracing.debugEnabled", false)
+}
 
-	// Handlers
+func setHandlerDefaults() {
 	viper.SetDefault("handlers.delivering.enabled", true)
 	viper.SetDefault("handlers.delivering.interval", "30s")
 	viper.SetDefault("handlers.delivering.initialDelay", "5s")
@@ -108,8 +130,9 @@ func setDefaults() {
 	viper.SetDefault("handlers.waiting.initialDelay", "15s")
 	viper.SetDefault("handlers.waiting.minMessageAge", "1m")
 	viper.SetDefault("handlers.waiting.maxMessageAge", "24h")
+}
 
-	// Notifications
+func setNotificationDefaults() {
 	viper.SetDefault("notifications.enabled", false)
 	viper.SetDefault("notifications.baseUrl", "https://galileo.example.com")
 	viper.SetDefault("notifications.loopModulo", 25)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,9 +6,10 @@ package config
 
 import (
 	"errors"
+	"strings"
+
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
-	"strings"
 )
 
 var Current Configuration
@@ -107,7 +108,7 @@ func setDefaults() {
 	viper.SetDefault("handlers.waiting.initialDelay", "15s")
 	viper.SetDefault("handlers.waiting.minMessageAge", "1m")
 	viper.SetDefault("handlers.waiting.maxMessageAge", "24h")
-	
+
 	// Notifications
 	viper.SetDefault("notifications.enabled", false)
 	viper.SetDefault("notifications.baseUrl", "https://galileo.example.com")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -137,7 +137,7 @@ type Notifications struct {
 }
 
 func (n Notifications) Options() *options.ClientOptions {
-	var opts = options.Client().
+	opts := options.Client().
 		SetBaseUrl(n.BaseUrl).
 		SetDebug(log.Logger.GetLevel() == zerolog.DebugLevel).
 		SetDryRun(false).

--- a/internal/handler/delivering.go
+++ b/internal/handler/delivering.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/message"
 	"github.com/telekom/pubsub-horizon-go/tracing"
 )
 
@@ -62,37 +63,44 @@ func CheckDeliveringEvents() {
 		log.Debug().Msgf("Found %d DELIVERING messages in MongoDb", len(dbMessages))
 
 		for _, dbMessage := range dbMessages {
-			if dbMessage.Coordinates == nil {
-				log.Warn().Msgf("Coordinates in message for subscriptionId %s are nil: %v", dbMessage.SubscriptionId, dbMessage)
+			if err := processDeliveringMessage(picker, &dbMessage); err != nil {
 				return
 			}
-
-			message, err := picker.Pick(&dbMessage)
-			if err != nil {
-				log.Error().Err(err).Msgf("Error while fetching message from kafka for subscriptionId %s", dbMessage.SubscriptionId)
-				return
-			}
-
-			b3Ctx := tracing.WithB3FromMessage(context.Background(), message)
-			traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
-
-			traceCtx.StartSpan("republish delivering message")
-			traceCtx.SetAttribute("component", "Horizon Golaris")
-			traceCtx.SetAttribute("eventId", dbMessage.Event.Id)
-			traceCtx.SetAttribute("eventType", dbMessage.Event.Type)
-			traceCtx.SetAttribute("subscriptionId", dbMessage.SubscriptionId)
-			traceCtx.SetAttribute("uuid", string(message.Key))
-
-			err = kafka.CurrentHandler.RepublishMessage(traceCtx, message, "", "", false)
-			if err != nil {
-				log.Error().Err(err).Msgf("Error while republishing message for subscriptionId %s", dbMessage.SubscriptionId)
-				return
-			}
-			log.Debug().Msgf("Successfully republished message in state DELIVERING for subscriptionId %s", dbMessage.SubscriptionId)
 		}
 
 		if len(dbMessages) < int(batchSize) {
 			break
 		}
 	}
+}
+
+func processDeliveringMessage(picker kafka.MessagePicker, dbMessage *message.StatusMessage) error {
+	if dbMessage.Coordinates == nil {
+		log.Warn().Msgf("Coordinates in message for subscriptionId %s are nil: %v", dbMessage.SubscriptionId, dbMessage)
+		return errAbort
+	}
+
+	msg, err := picker.Pick(dbMessage)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error while fetching message from kafka for subscriptionId %s", dbMessage.SubscriptionId)
+		return errAbort
+	}
+
+	b3Ctx := tracing.WithB3FromMessage(context.Background(), msg)
+	traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
+
+	traceCtx.StartSpan("republish delivering message")
+	traceCtx.SetAttribute("component", "Horizon Golaris")
+	traceCtx.SetAttribute("eventId", dbMessage.Event.Id)
+	traceCtx.SetAttribute("eventType", dbMessage.Event.Type)
+	traceCtx.SetAttribute("subscriptionId", dbMessage.SubscriptionId)
+	traceCtx.SetAttribute("uuid", string(msg.Key))
+
+	err = kafka.CurrentHandler.RepublishMessage(traceCtx, msg, "", "", false)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error while republishing message for subscriptionId %s", dbMessage.SubscriptionId)
+		return errAbort
+	}
+	log.Debug().Msgf("Successfully republished message in state DELIVERING for subscriptionId %s", dbMessage.SubscriptionId)
+	return nil
 }

--- a/internal/handler/delivering.go
+++ b/internal/handler/delivering.go
@@ -6,19 +6,20 @@ package handler
 
 import (
 	"context"
-	"github.com/rs/zerolog/log"
-	"github.com/telekom/pubsub-horizon-go/tracing"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/kafka"
 	"pubsub-horizon-golaris/internal/mongo"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/tracing"
 )
 
 func CheckDeliveringEvents() {
 	log.Debug().Msgf("DeliveringHandler: Republish messages in state DELIVERING")
 
-	var ctx = cache.HandlerCache.NewLockContext(context.Background())
+	ctx := cache.HandlerCache.NewLockContext(context.Background())
 
 	if acquired, err := cache.HandlerCache.TryLockWithTimeout(ctx, cache.DeliveringLockKey, 100*time.Millisecond); err != nil {
 		log.Error().Err(err).Msgf("Error acquiring lock for DeliveringHandler entry: %s", cache.DeliveringLockKey)
@@ -45,14 +46,15 @@ func CheckDeliveringEvents() {
 	}
 	defer picker.Close()
 
-	for {
-		var lastTimestamp any
+	var lastTimestamp any
 
-		dbMessages, lastTimestamp, err := mongo.CurrentConnection.FindDeliveringMessagesByDeliveryType(upperThresholdTimestamp, lastTimestamp)
+	for {
+		dbMessages, newTimestamp, err := mongo.CurrentConnection.FindDeliveringMessagesByDeliveryType(upperThresholdTimestamp, lastTimestamp)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error while fetching DELIVERING messages from MongoDb")
 			return
 		}
+		lastTimestamp = newTimestamp
 
 		if len(dbMessages) == 0 {
 			return
@@ -60,7 +62,6 @@ func CheckDeliveringEvents() {
 		log.Debug().Msgf("Found %d DELIVERING messages in MongoDb", len(dbMessages))
 
 		for _, dbMessage := range dbMessages {
-
 			if dbMessage.Coordinates == nil {
 				log.Warn().Msgf("Coordinates in message for subscriptionId %s are nil: %v", dbMessage.SubscriptionId, dbMessage)
 				return
@@ -72,8 +73,8 @@ func CheckDeliveringEvents() {
 				return
 			}
 
-			var b3Ctx = tracing.WithB3FromMessage(context.Background(), message)
-			var traceCtx = tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
+			b3Ctx := tracing.WithB3FromMessage(context.Background(), message)
+			traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
 
 			traceCtx.StartSpan("republish delivering message")
 			traceCtx.SetAttribute("component", "Horizon Golaris")

--- a/internal/handler/delivering_test.go
+++ b/internal/handler/delivering_test.go
@@ -6,9 +6,6 @@ package handler
 
 import (
 	"context"
-	"github.com/IBM/sarama"
-	"github.com/stretchr/testify/mock"
-	"github.com/telekom/pubsub-horizon-go/message"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/kafka"
@@ -16,6 +13,10 @@ import (
 	"pubsub-horizon-golaris/internal/test"
 	"testing"
 	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/mock"
+	"github.com/telekom/pubsub-horizon-go/message"
 )
 
 func TestCheckDeliveringEvents_Success(t *testing.T) {
@@ -52,7 +53,8 @@ func TestCheckDeliveringEvents_Success(t *testing.T) {
 			Coordinates: &message.Coordinates{
 				Partition: &partitionValue1,
 				Offset:    &offsetValue1,
-			}},
+			},
+		},
 		{
 			Topic:          "test-topic",
 			Status:         "DELIVERING",
@@ -61,7 +63,8 @@ func TestCheckDeliveringEvents_Success(t *testing.T) {
 			Coordinates: &message.Coordinates{
 				Partition: &partitionValue2,
 				Offset:    &offsetValue2,
-			}},
+			},
+		},
 	}
 
 	mockMongo.On("FindDeliveringMessagesByDeliveryType", mock.Anything, mock.Anything).Return(dbMessages, nil, nil)

--- a/internal/handler/failed.go
+++ b/internal/handler/failed.go
@@ -6,20 +6,21 @@ package handler
 
 import (
 	"context"
-	"github.com/rs/zerolog/log"
-	"github.com/telekom/pubsub-horizon-go/message"
-	"github.com/telekom/pubsub-horizon-go/tracing"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/kafka"
 	"pubsub-horizon-golaris/internal/mongo"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/tracing"
 )
 
 func CheckFailedEvents() {
 	log.Debug().Msgf("FailedHandler: Republish messages in state FAILED")
 
-	var ctx = cache.HandlerCache.NewLockContext(context.Background())
+	ctx := cache.HandlerCache.NewLockContext(context.Background())
 
 	if acquired, err := cache.HandlerCache.TryLockWithTimeout(ctx, cache.FailedLockKey, 100*time.Millisecond); err != nil {
 		log.Error().Err(err).Msgf("Error acquiring lock for FailedHandler entry: %s", cache.FailedLockKey)
@@ -70,7 +71,7 @@ func CheckFailedEvents() {
 
 			if subscription != nil {
 				if subscription.Spec.Subscription.DeliveryType == "sse" || subscription.Spec.Subscription.DeliveryType == "server_sent_event" {
-					var newDeliveryType = "SERVER_SENT_EVENT"
+					newDeliveryType := "SERVER_SENT_EVENT"
 
 					if dbMessage.Coordinates == nil {
 						log.Warn().Msgf("Coordinates in message for subscriptionId %s are nil: %v", dbMessage.SubscriptionId, dbMessage)
@@ -83,8 +84,8 @@ func CheckFailedEvents() {
 						return
 					}
 
-					var b3Ctx = tracing.WithB3FromMessage(context.Background(), kafkaMessage)
-					var traceCtx = tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
+					b3Ctx := tracing.WithB3FromMessage(context.Background(), kafkaMessage)
+					traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
 
 					traceCtx.StartSpan("republish failed message")
 					traceCtx.SetAttribute("component", "Horizon Golaris")
@@ -99,7 +100,6 @@ func CheckFailedEvents() {
 						return
 					}
 					log.Debug().Msgf("Successfully republished message in state FAILED for subscriptionId %s", subscriptionId)
-
 				}
 			}
 		}

--- a/internal/handler/failed.go
+++ b/internal/handler/failed.go
@@ -6,16 +6,22 @@ package handler
 
 import (
 	"context"
+	"errors"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/kafka"
 	"pubsub-horizon-golaris/internal/mongo"
 	"time"
 
+	"github.com/IBM/sarama"
 	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/enum"
 	"github.com/telekom/pubsub-horizon-go/message"
 	"github.com/telekom/pubsub-horizon-go/tracing"
 )
+
+// errAbort signals that batch processing should stop without logging an additional error.
+var errAbort = errors.New("abort processing")
 
 func CheckFailedEvents() {
 	log.Debug().Msgf("FailedHandler: Republish messages in state FAILED")
@@ -61,46 +67,8 @@ func CheckFailedEvents() {
 		}
 
 		for _, dbMessage := range dbMessages {
-			subscriptionId := dbMessage.SubscriptionId
-
-			subscription, err := cache.SubscriptionCache.Get(config.Current.Hazelcast.Caches.SubscriptionCache, subscriptionId)
-			if err != nil {
-				log.Error().Err(err).Msgf("Error while fetching republishing entry for subscriptionId %s", subscriptionId)
+			if err := republishFailedMessage(&dbMessage, picker); err != nil {
 				return
-			}
-
-			if subscription != nil {
-				if subscription.Spec.Subscription.DeliveryType == "sse" || subscription.Spec.Subscription.DeliveryType == "server_sent_event" {
-					newDeliveryType := "SERVER_SENT_EVENT"
-
-					if dbMessage.Coordinates == nil {
-						log.Warn().Msgf("Coordinates in message for subscriptionId %s are nil: %v", dbMessage.SubscriptionId, dbMessage)
-						return
-					}
-
-					kafkaMessage, err := picker.Pick(&dbMessage)
-					if err != nil {
-						log.Error().Err(err).Msgf("Error while fetching message from kafka for subscriptionId %s", subscriptionId)
-						return
-					}
-
-					b3Ctx := tracing.WithB3FromMessage(context.Background(), kafkaMessage)
-					traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
-
-					traceCtx.StartSpan("republish failed message")
-					traceCtx.SetAttribute("component", "Horizon Golaris")
-					traceCtx.SetAttribute("eventId", dbMessage.Event.Id)
-					traceCtx.SetAttribute("eventType", dbMessage.Event.Type)
-					traceCtx.SetAttribute("subscriptionId", dbMessage.SubscriptionId)
-					traceCtx.SetAttribute("uuid", string(kafkaMessage.Key))
-
-					err = kafka.CurrentHandler.RepublishMessage(traceCtx, kafkaMessage, newDeliveryType, "", true)
-					if err != nil {
-						log.Error().Err(err).Msgf("Error while republishing message for subscriptionId %s", subscriptionId)
-						return
-					}
-					log.Debug().Msgf("Successfully republished message in state FAILED for subscriptionId %s", subscriptionId)
-				}
 			}
 		}
 
@@ -108,4 +76,62 @@ func CheckFailedEvents() {
 			break
 		}
 	}
+}
+
+func republishFailedMessage(dbMessage *message.StatusMessage, picker kafka.MessagePicker) error {
+	subscriptionId := dbMessage.SubscriptionId
+
+	subscription, err := cache.SubscriptionCache.Get(config.Current.Hazelcast.Caches.SubscriptionCache, subscriptionId)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error while fetching republishing entry for subscriptionId %s", subscriptionId)
+		return err
+	}
+
+	if subscription == nil {
+		return nil
+	}
+
+	if !isSSEDeliveryType(subscription.Spec.Subscription.DeliveryType) {
+		return nil
+	}
+
+	if dbMessage.Coordinates == nil {
+		log.Warn().Msgf("Coordinates in message for subscriptionId %s are nil: %v", dbMessage.SubscriptionId, dbMessage)
+		return errAbort
+	}
+
+	kafkaMessage, err := picker.Pick(dbMessage)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error while fetching message from kafka for subscriptionId %s", subscriptionId)
+		return err
+	}
+
+	traceCtx := startRepublishTrace(kafkaMessage, dbMessage)
+
+	err = kafka.CurrentHandler.RepublishMessage(traceCtx, kafkaMessage, "SERVER_SENT_EVENT", "", true)
+	if err != nil {
+		log.Error().Err(err).Msgf("Error while republishing message for subscriptionId %s", subscriptionId)
+		return err
+	}
+
+	log.Debug().Msgf("Successfully republished message in state FAILED for subscriptionId %s", subscriptionId)
+	return nil
+}
+
+func isSSEDeliveryType(deliveryType enum.DeliveryType) bool {
+	return deliveryType == "sse" || deliveryType == "server_sent_event"
+}
+
+func startRepublishTrace(kafkaMessage *sarama.ConsumerMessage, dbMessage *message.StatusMessage) *tracing.TraceContext {
+	b3Ctx := tracing.WithB3FromMessage(context.Background(), kafkaMessage)
+	traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
+
+	traceCtx.StartSpan("republish failed message")
+	traceCtx.SetAttribute("component", "Horizon Golaris")
+	traceCtx.SetAttribute("eventId", dbMessage.Event.Id)
+	traceCtx.SetAttribute("eventType", dbMessage.Event.Type)
+	traceCtx.SetAttribute("subscriptionId", dbMessage.SubscriptionId)
+	traceCtx.SetAttribute("uuid", string(kafkaMessage.Key))
+
+	return traceCtx
 }

--- a/internal/handler/failed.go
+++ b/internal/handler/failed.go
@@ -54,13 +54,16 @@ func CheckFailedEvents() {
 	}
 	defer picker.Close()
 
+	var lastTimestamp any
+
 	for {
-		var lastTimestamp any
-		dbMessages, _, err = mongo.CurrentConnection.FindFailedMessagesWithCallbackUrlNotFoundException(time.Now(), lastTimestamp)
+		var newTimestamp any
+		dbMessages, newTimestamp, err = mongo.CurrentConnection.FindFailedMessagesWithCallbackUrlNotFoundException(time.Now(), lastTimestamp)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error while fetching FAILED messages from MongoDb")
 			return
 		}
+		lastTimestamp = newTimestamp
 
 		if len(dbMessages) == 0 {
 			return

--- a/internal/handler/failed_test.go
+++ b/internal/handler/failed_test.go
@@ -6,17 +6,18 @@ package handler
 
 import (
 	"context"
-	"github.com/IBM/sarama"
-	"github.com/stretchr/testify/mock"
-	"github.com/telekom/pubsub-horizon-go/enum"
-	"github.com/telekom/pubsub-horizon-go/message"
-	"github.com/telekom/pubsub-horizon-go/resource"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/kafka"
 	"pubsub-horizon-golaris/internal/mongo"
 	"pubsub-horizon-golaris/internal/test"
 	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/mock"
+	"github.com/telekom/pubsub-horizon-go/enum"
+	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
 func TestCheckFailedEvents(t *testing.T) {
@@ -53,7 +54,8 @@ func TestCheckFailedEvents(t *testing.T) {
 			Coordinates: &message.Coordinates{
 				Partition: &partitionValue,
 				Offset:    &offsetValue,
-			}},
+			},
+		},
 	}
 
 	subscription := &resource.SubscriptionResource{

--- a/internal/handler/waiting.go
+++ b/internal/handler/waiting.go
@@ -37,7 +37,7 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 	maxMessageAge := config.Current.Handlers.Waiting.MaxMessageAge
 
 	// Create a WaitingHandler entry and lock it
-	var ctx = cache.HandlerCache.NewLockContext(context.Background())
+	ctx := cache.HandlerCache.NewLockContext(context.Background())
 
 	if acquired, err := cache.HandlerCache.TryLockWithTimeout(ctx, cache.WaitingLockKey, 100*time.Millisecond); err != nil {
 		log.Error().Err(err).Msgf("WaitingHandler: Error acquiring lock for WaitingHandler entry: %s", cache.WaitingLockKey)
@@ -54,14 +54,19 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 	}()
 
 	// Get all subscriptions (distinct) for messages in state WAITING from db
-	dbSubscriptionsForWaitingEvents, err := mongo.CurrentConnection.FindDistinctSubscriptionsForWaitingEvents(time.Now().Add(-maxMessageAge), time.Now().Add(-minMessageAge))
+	dbSubscriptionsForWaitingEvents, err := mongo.CurrentConnection.FindDistinctSubscriptionsForWaitingEvents(
+		time.Now().Add(-maxMessageAge),
+		time.Now().Add(-minMessageAge),
+	)
 	if err != nil {
 		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching distinct subscriptions for events stuck in state WAITING from db")
 		return
 	}
 
 	// If no subscriptions found, return
-	log.Debug().Msgf("WaitingHandler: Found %d subscriptions with waiting messages: %v", len(dbSubscriptionsForWaitingEvents), dbSubscriptionsForWaitingEvents)
+	log.Debug().
+		Msgf("WaitingHandler: Found %d subscriptions with waiting messages: %v",
+			len(dbSubscriptionsForWaitingEvents), dbSubscriptionsForWaitingEvents)
 	if len(dbSubscriptionsForWaitingEvents) == 0 {
 		return
 	}
@@ -80,7 +85,9 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 		log.Error().Err(err).Msgf("WaitingHandler: Error while fetching circuit breaker cache entries for events stuck in state WAITING")
 		return
 	}
-	log.Debug().Msgf("WaitingHandler: Found %d circuitbreaker entries in state OPEN: %v", len(circuitBreakerSubscriptionsMap), circuitBreakerSubscriptionsMap)
+	log.Debug().
+		Msgf("WaitingHandler: Found %d circuitbreaker entries in state OPEN: %v",
+			len(circuitBreakerSubscriptionsMap), circuitBreakerSubscriptionsMap)
 
 	// Check if subscription is in republishing cache or in circuit breaker cache. If not create a republishing cache entry
 	for _, subscriptionId := range dbSubscriptionsForWaitingEvents {
@@ -88,7 +95,11 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 		_, inRepublishing := republishingSubscriptionsMap[subscriptionId]
 		_, inCircuitBreaker := circuitBreakerSubscriptionsMap[subscriptionId]
 		if !inRepublishing && !inCircuitBreaker {
-			log.Warn().Msgf("WaitingHandler: Subscription %v has waiting messages and no circuitbreaker entry and no republishing entry!. Creating republishing entry for events stuck in state WAITING", subscriptionId)
+			log.Warn().
+				Msgf("WaitingHandler: Subscription %v has waiting messages and no "+
+					"circuitbreaker entry and no republishing entry!. "+
+					"Creating republishing entry for events stuck in state WAITING",
+					subscriptionId)
 
 			// Create republishing cache entry for subscription with stuck waiting events
 			republishingCacheEntry := republish.RepublishingCacheEntry{
@@ -96,13 +107,20 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 				RepublishingUpTo: time.Now(),
 				PostponedUntil:   time.Now(),
 			}
-			
+
 			err := circuitbreaker.SetNewRepublishingCacheEntry(context.Background(), republishingCacheEntry, subscriptionId, false)
 			if err != nil {
-				log.Error().Err(err).Msgf("WaitingHandler: Error while creating RepublishingCacheEntry entry for events stuck in state WAITING. subscriptionId: %s", subscriptionId)
+				log.Error().
+					Err(err).
+					Msgf("WaitingHandler: Error while creating RepublishingCacheEntry "+
+						"entry for events stuck in state WAITING. subscriptionId: %s",
+						subscriptionId)
 				continue
 			}
-			log.Debug().Msgf("WaitingHandler: Successfully created RepublishingCacheEntry entry for for events stuck in state WAITING. subscriptionId: %s", subscriptionId)
+			log.Debug().
+				Msgf("WaitingHandler: Successfully created RepublishingCacheEntry "+
+					"entry for events stuck in state WAITING. subscriptionId: %s",
+					subscriptionId)
 		}
 	}
 	log.Debug().Msgf("WaitingHandler: Finished republishing messages stuck in state WAITING")
@@ -110,7 +128,6 @@ func (waitingHandler *waitingHandler) CheckWaitingEvents() {
 
 // GetCircuitBreakerSubscriptionsMap returns a map of subscriptions with open circuit breaker entries.
 func (waitingHandler *waitingHandler) GetCircuitBreakerSubscriptionsMap() (map[string]struct{}, error) {
-
 	statusQuery := predicate.Equal("status", string(enum.CircuitBreakerStatusOpen))
 	circuitBreakerEntries, err := cache.CircuitBreakerCache.GetQuery(config.Current.Hazelcast.Caches.CircuitBreakerCache, statusQuery)
 	if err != nil {
@@ -126,7 +143,6 @@ func (waitingHandler *waitingHandler) GetCircuitBreakerSubscriptionsMap() (map[s
 
 // GetRepublishingSubscriptionsMap returns a map of subscriptions with republishing entries.
 func (waitingHandler *waitingHandler) GetRepublishingSubscriptionsMap() (map[string]struct{}, error) {
-
 	cacheRepublishingEntries, err := cache.RepublishingCache.GetEntrySet(context.Background())
 	if err != nil {
 		return nil, err

--- a/internal/handler/waiting_test.go
+++ b/internal/handler/waiting_test.go
@@ -6,22 +6,22 @@ package handler
 
 import (
 	"context"
-	"fmt"
+	"errors"
+	"pubsub-horizon-golaris/internal/cache"
+	"pubsub-horizon-golaris/internal/mongo"
+	"pubsub-horizon-golaris/internal/republish"
+	"pubsub-horizon-golaris/internal/test"
+	"testing"
+
 	"github.com/hazelcast/hazelcast-go-client/predicate"
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/telekom/pubsub-horizon-go/enum"
 	"github.com/telekom/pubsub-horizon-go/message"
-	"pubsub-horizon-golaris/internal/cache"
-	"pubsub-horizon-golaris/internal/mongo"
-	"pubsub-horizon-golaris/internal/republish"
-	"pubsub-horizon-golaris/internal/test"
-	"testing"
 )
 
 func TestCheckWaitingEvents_NoActionNeededWhileNoWaitingEvents(t *testing.T) {
-
 	mockMongo := new(test.MockMongoHandler)
 	mongo.CurrentConnection = mockMongo
 
@@ -65,7 +65,6 @@ func TestCheckWaitingEvents_NoActionNeededWhileNoWaitingEvents(t *testing.T) {
 }
 
 func TestCheckWaitingEvents_NoActionNeededWhileExistingCbEntry(t *testing.T) {
-
 	mockMongo := new(test.MockMongoHandler)
 	mongo.CurrentConnection = mockMongo
 
@@ -79,9 +78,9 @@ func TestCheckWaitingEvents_NoActionNeededWhileExistingCbEntry(t *testing.T) {
 	cache.RepublishingCache = mockRepublishingCache
 
 	// Prepare testdata
-	var mockedDbSubscriptionIds = []string{"subscription-1"}                                  // two subscriptions with waiting events in db
-	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{"subscription-1": struct{}{}} // existing circuit breaker entries
-	mockedRepublishingSubscriptionsMap := map[string]struct{}{}                               // no republishing entries
+	mockedDbSubscriptionIds := []string{"subscription-1"}                             // two subscriptions with waiting events in db
+	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{"subscription-1": {}} // existing circuit breaker entries
+	mockedRepublishingSubscriptionsMap := map[string]struct{}{}                       // no republishing entries
 
 	// Prepare mocks
 	mockHandlerCache.On("NewLockContext", mock.Anything).Return(context.Background())
@@ -108,7 +107,6 @@ func TestCheckWaitingEvents_NoActionNeededWhileExistingCbEntry(t *testing.T) {
 }
 
 func TestCheckWaitingEvents_NoActionNeededWhileExistingRepublishEntry(t *testing.T) {
-
 	mockMongo := new(test.MockMongoHandler)
 	mongo.CurrentConnection = mockMongo
 
@@ -122,9 +120,11 @@ func TestCheckWaitingEvents_NoActionNeededWhileExistingRepublishEntry(t *testing
 	cache.RepublishingCache = mockRepublishingCache
 
 	// Prepare testdata
-	var mockedDbSubscriptionIds = []string{"subscription-1"}                                // two subscriptions with waiting events in db
-	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{}                           // no circuit breaker entries
-	mockedRepublishingSubscriptionsMap := map[string]struct{}{"subscription-1": struct{}{}} // existing republishing entries                                                       // no republishing entries
+	mockedDbSubscriptionIds := []string{"subscription-1"}         // two subscriptions with waiting events in db
+	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{} // no circuit breaker entries
+	mockedRepublishingSubscriptionsMap := map[string]struct{}{
+		"subscription-1": {},
+	} // existing republishing entries                                                       // no republishing entries
 
 	// Prepare mocks
 	mockHandlerCache.On("NewLockContext", mock.Anything).Return(context.Background())
@@ -151,7 +151,6 @@ func TestCheckWaitingEvents_NoActionNeededWhileExistingRepublishEntry(t *testing
 }
 
 func TestCheckWaitingEvents_ActionNeededWhileNoMatchingCacheEntries(t *testing.T) {
-
 	mockMongo := new(test.MockMongoHandler)
 	mongo.CurrentConnection = mockMongo
 
@@ -165,9 +164,14 @@ func TestCheckWaitingEvents_ActionNeededWhileNoMatchingCacheEntries(t *testing.T
 	cache.RepublishingCache = mockRepublishingCache
 
 	// Prepare testdata
-	var mockedDbSubscriptionIds = []string{"subscription-1", "subscription-2"}                             // two subscriptions with waiting events in db
-	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{"not-matching-subscription-1": struct{}{}} // no circuit breaker entries
-	mockedRepublishingSubscriptionsMap := map[string]struct{}{"not-matching-subscription-2": struct{}{}}   // no republishing entries                                                       // no republishing entries
+	mockedDbSubscriptionIds := []string{
+		"subscription-1",
+		"subscription-2",
+	} // two subscriptions with waiting events in db
+	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{"not-matching-subscription-1": {}} // no circuit breaker entries
+	mockedRepublishingSubscriptionsMap := map[string]struct{}{
+		"not-matching-subscription-2": {},
+	} // no republishing entries                                                       // no republishing entries
 
 	// Prepare mocks
 	mockHandlerCache.On("NewLockContext", mock.Anything).Return(context.Background())
@@ -194,7 +198,6 @@ func TestCheckWaitingEvents_ActionNeededWhileNoMatchingCacheEntries(t *testing.T
 }
 
 func TestCheckWaitingEvents_ActionNeededWhileSubsetHasNoCacheEntries(t *testing.T) {
-
 	mockMongo := new(test.MockMongoHandler)
 	mongo.CurrentConnection = mockMongo
 
@@ -208,9 +211,11 @@ func TestCheckWaitingEvents_ActionNeededWhileSubsetHasNoCacheEntries(t *testing.
 	cache.RepublishingCache = mockRepublishingCache
 
 	// Prepare testdata
-	var mockedDbSubscriptionIds = []string{"subscription-1", "subscription-2"}                // two subscriptions with waiting events in db
-	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{"subscription-1": struct{}{}} // existing circuit breaker entry for one subscription         // no circuit breaker entries
-	mockedRepublishingSubscriptionsMap := map[string]struct{}{}                               // no republishing entries                                                       // no republishing entries
+	mockedDbSubscriptionIds := []string{"subscription-1", "subscription-2"} // two subscriptions with waiting events in db
+	mockedCircuitBreakerSubscriptionsMap := map[string]struct{}{
+		"subscription-1": {},
+	} // existing circuit breaker entry for one subscription         // no circuit breaker entries
+	mockedRepublishingSubscriptionsMap := map[string]struct{}{} // no republishing entries
 
 	// Prepare mocks
 	mockHandlerCache.On("NewLockContext", mock.Anything).Return(context.Background())
@@ -237,7 +242,6 @@ func TestCheckWaitingEvents_ActionNeededWhileSubsetHasNoCacheEntries(t *testing.
 }
 
 func TestGetCircuitBreakerSubscriptionsMap_ReturnsCorrectSubscriptions(t *testing.T) {
-
 	// CircuitBreakerCache is needed for this test
 	mockCircuitBreakerCache := new(test.CircuitBreakerMockCache)
 	cache.CircuitBreakerCache = mockCircuitBreakerCache
@@ -291,7 +295,7 @@ func TestGetCircuitBreakerSubscriptionsMap_CacheError(t *testing.T) {
 	// Create empty test data
 	circuitBreakerEntries := []message.CircuitBreakerMessage{}
 	statusQuery := predicate.Equal("status", string(enum.CircuitBreakerStatusOpen))
-	mockCircuitBreakerCache.On("GetQuery", mock.Anything, statusQuery).Return(circuitBreakerEntries, fmt.Errorf("cache retrieval error"))
+	mockCircuitBreakerCache.On("GetQuery", mock.Anything, statusQuery).Return(circuitBreakerEntries, errors.New("cache retrieval error"))
 
 	// Call the method to test
 	waitingHandler := new(waitingHandler)
@@ -352,7 +356,7 @@ func TestGetRepublishingSubscriptionsMap_CacheError(t *testing.T) {
 	cache.RepublishingCache = mockRepulishingCache
 
 	// Simulate cache retrieval error
-	mockRepulishingCache.On("GetEntrySet", mock.Anything).Return([]types.Entry{}, fmt.Errorf("cache retrieval error"))
+	mockRepulishingCache.On("GetEntrySet", mock.Anything).Return([]types.Entry{}, errors.New("cache retrieval error"))
 
 	// Call the method to test
 	waitingHandler := new(waitingHandler)

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -8,14 +8,15 @@ import (
 	"context"
 	"encoding/gob"
 	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/telekom/pubsub-horizon-go/resource"
 	"net/http"
 	"pubsub-horizon-golaris/internal/auth"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
 // register the data type HealthCheckCacheEntry to gob for encoding and decoding of binary data
@@ -56,16 +57,16 @@ func IsHealthCheckInCoolDown(healthCheckData HealthCheckCacheEntry) bool {
 
 // getCredentialsForEnvironment resolves the credentials for the given environment.
 func getCredentialsForEnvironment(environment string) (string, string, string, error) {
-	var issuerUrl = strings.ReplaceAll(config.Current.Security.Url, "<realm>", environment)
+	issuerUrl := strings.ReplaceAll(config.Current.Security.Url, "<realm>", environment)
 
-	var secrets = make(map[string]string)
+	secrets := make(map[string]string)
 	for _, secret := range config.Current.Security.ClientSecret {
-		var splittedSecret = strings.SplitN(secret, "=", 2)
+		splittedSecret := strings.SplitN(secret, "=", 2)
 		if len(splittedSecret) < 2 {
 			return "", "", "", fmt.Errorf("could not resolve secret '%s' for environment '%s'", secret, environment)
 		}
 
-		var clientEnvironment, clientSecret = splittedSecret[0], splittedSecret[1]
+		clientEnvironment, clientSecret := splittedSecret[0], splittedSecret[1]
 		secrets[clientEnvironment] = clientSecret
 	}
 
@@ -77,7 +78,7 @@ func getCredentialsForEnvironment(environment string) (string, string, string, e
 func CheckConsumerHealth(hcData *PreparedHealthCheckData, subscription *resource.SubscriptionResource) error {
 	log.Debug().Msg("Checking consumer health")
 
-	var issuerUrl, clientId, clientSecret, err = getCredentialsForEnvironment(subscription.Spec.Environment)
+	issuerUrl, clientId, clientSecret, err := getCredentialsForEnvironment(subscription.Spec.Environment)
 	if err != nil {
 		return err
 	}
@@ -88,43 +89,49 @@ func CheckConsumerHealth(hcData *PreparedHealthCheckData, subscription *resource
 		return err
 	}
 
-	resp, err := executeHealthRequestWithToken(hcData.HealthCheckEntry.CallbackUrl, hcData.HealthCheckEntry.Method, subscription, token)
+	statusCode, err := executeHealthRequestWithToken(hcData.HealthCheckEntry.CallbackUrl, hcData.HealthCheckEntry.Method, subscription, token)
 	if err != nil {
 		log.Info().Err(err).Msgf("Failed to perform http-request for callback-url %s", hcData.HealthCheckEntry.CallbackUrl)
 		updateHealthCheckEntry(hcData.Ctx, hcData.HealthCheckKey, hcData.HealthCheckEntry, 0)
 		return err
 	}
-	log.Debug().Msgf("Received response for callback-url %s with http-status: %v", hcData.HealthCheckEntry.CallbackUrl, resp.StatusCode)
+	log.Debug().Msgf("Received response for callback-url %s with http-status: %v", hcData.HealthCheckEntry.CallbackUrl, statusCode)
 
-	hcData.HealthCheckEntry.LastCheckedStatus = resp.StatusCode
-	updateHealthCheckEntry(hcData.Ctx, hcData.HealthCheckKey, hcData.HealthCheckEntry, resp.StatusCode)
+	hcData.HealthCheckEntry.LastCheckedStatus = statusCode
+	updateHealthCheckEntry(hcData.Ctx, hcData.HealthCheckKey, hcData.HealthCheckEntry, statusCode)
 
 	return nil
 }
 
-func executeHealthRequestWithToken(callbackUrl string, httpMethod string, subscription *resource.SubscriptionResource, token string) (*http.Response, error) {
+func executeHealthRequestWithToken(
+	callbackUrl, httpMethod string,
+	subscription *resource.SubscriptionResource,
+	token string,
+) (int, error) {
 	log.Debug().Msgf("Performing health request for calllback-url %s with http-method %s", callbackUrl, httpMethod)
 
-	request, err := http.NewRequest(httpMethod, callbackUrl, nil)
+	request, err := http.NewRequestWithContext(context.Background(), httpMethod, callbackUrl, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create request for URL %s: %v", callbackUrl, err)
+		return 0, fmt.Errorf("failed to create request for URL %s: %w", callbackUrl, err)
 	}
 
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
-	request.Header.Add("x-pubsub-publisher-id", subscription.Spec.Subscription.PublisherId)
-	request.Header.Add("x-pubsub-subscriber-id", subscription.Spec.Subscription.SubscriberId)
+	request.Header.Add("Authorization", "Bearer "+token)
+	request.Header.Add("X-Pubsub-Publisher-Id", subscription.Spec.Subscription.PublisherId)
+	request.Header.Add("X-Pubsub-Subscriber-Id", subscription.Spec.Subscription.SubscriberId)
 
 	response, err := auth.Client.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to perform %s request to %s: %v", httpMethod, callbackUrl, err)
+		return 0, fmt.Errorf("failed to perform %s request to %s: %w", httpMethod, callbackUrl, err)
 	}
 	defer response.Body.Close()
 
-	return response, nil
+	return response.StatusCode, nil
 }
 
-// PrepareHealthCheck tries to get an entry from the HealthCheckCache. If no entry exists it creates a new one. The entry then gets locked.
-// It returns a PreparedHealthCheckData struct containing the context, health check key, health check entry, and a boolean indicating if the lock was acquired.
+// PrepareHealthCheck tries to get an entry from the HealthCheckCache. If no entry exists
+// it creates a new one. The entry then gets locked. It returns a PreparedHealthCheckData
+// struct containing the context, health check key, health check entry, and a boolean
+// indicating if the lock was acquired.
 func PrepareHealthCheck(subscription *resource.SubscriptionResource) (*PreparedHealthCheckData, error) {
 	httpMethod := GetHttpMethod(subscription)
 
@@ -150,17 +157,22 @@ func PrepareHealthCheck(subscription *resource.SubscriptionResource) (*PreparedH
 	}
 
 	// Attempt to acquire a lock for the health check key
-	//isAcquired, _ := cache.HealthCheckCache.TryLockWithTimeout(ctx, healthCheckKey, 10*time.Millisecond)
+	// isAcquired, _ := cache.HealthCheckCache.TryLockWithTimeout(ctx, healthCheckKey, 10*time.Millisecond)
 	isAcquired, _ := cache.HealthCheckCache.TryLockWithLeaseAndTimeout(ctx, healthCheckKey, 60000*time.Millisecond, 100*time.Millisecond)
 
 	castedHealthCheckEntry := healthCheckEntry.(HealthCheckCacheEntry)
-	return &PreparedHealthCheckData{Ctx: ctx, HealthCheckKey: healthCheckKey, HealthCheckEntry: castedHealthCheckEntry, IsAcquired: isAcquired}, nil
+	return &PreparedHealthCheckData{
+		Ctx:              ctx,
+		HealthCheckKey:   healthCheckKey,
+		HealthCheckEntry: castedHealthCheckEntry,
+		IsAcquired:       isAcquired,
+	}, nil
 }
 
 // GetHttpMethod specifies the HTTP method based on the subscription configuration
 func GetHttpMethod(subscription *resource.SubscriptionResource) string {
 	httpMethod := http.MethodHead
-	if subscription.Spec.Subscription.EnforceGetHealthCheck == true {
+	if subscription.Spec.Subscription.EnforceGetHealthCheck {
 		httpMethod = http.MethodGet
 	}
 	return httpMethod

--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -7,16 +7,17 @@ package healthcheck
 import (
 	"context"
 	"fmt"
-	"github.com/jarcoal/httpmock"
-	"github.com/rs/zerolog/log"
-	"github.com/stretchr/testify/assert"
-	"github.com/telekom/pubsub-horizon-go/resource"
 	"os"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/test"
 	"testing"
 	"time"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
 func TestMain(m *testing.M) {
@@ -33,7 +34,7 @@ func TestMain(m *testing.M) {
 }
 
 func Test_CheckConsumerHealthSuccess(t *testing.T) {
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	config.Current.Security.Url = "https://tokenUrl"
 
@@ -80,7 +81,7 @@ func Test_CheckConsumerHealthSuccess(t *testing.T) {
 }
 
 func Test_ExecuteHealthRequestWithToken(t *testing.T) {
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -107,19 +108,18 @@ func Test_ExecuteHealthRequestWithToken(t *testing.T) {
 	token := "dummy_token"
 
 	for _, method := range []string{"GET", "HEAD"} {
-		response, err := executeHealthRequestWithToken("https://consumerUrl", method, subscription, token)
+		statusCode, err := executeHealthRequestWithToken("https://consumerUrl", method, subscription, token)
 		if err != nil {
 			t.Errorf("Error executing %s request: %v", method, err)
 			continue
 		}
 
-		assertions.NotNil(response)
-		assertions.Equal(200, response.StatusCode)
+		assertions.Equal(200, statusCode)
 	}
 }
 
 func Test_ExecuteHealthRequestWithToken_ErrorCases(t *testing.T) {
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
@@ -147,25 +147,24 @@ func Test_ExecuteHealthRequestWithToken_ErrorCases(t *testing.T) {
 
 	for _, method := range []string{"GET", "HEAD"} {
 		callbackUrl := "https://invalidConsumerUrl"
-		response, err := executeHealthRequestWithToken(callbackUrl, method, mockSubscription, token)
-		assertions.Equal(400, response.StatusCode)
+		statusCode, err := executeHealthRequestWithToken(callbackUrl, method, mockSubscription, token)
+		assertions.Equal(400, statusCode)
 		if err != nil {
-			assertions.Nil(response)
+			assertions.Equal(0, statusCode)
 			assertions.Error(err)
 
-			expectedErrMsg := fmt.Sprintf("Failed to perform %s request to %s:", method, callbackUrl)
+			expectedErrMsg := fmt.Sprintf("failed to perform %s request to %s:", method, callbackUrl)
 			assertions.Contains(err.Error(), expectedErrMsg)
 
 			log.Info().Err(err).Msgf("Error occured")
 			continue
 		}
 	}
-
 }
 
 func TestPrepareHealthCheck_ExistingEntry(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -199,7 +198,7 @@ func TestPrepareHealthCheck_ExistingEntry(t *testing.T) {
 
 func TestGetHttpMethod_HeadMethod(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -218,7 +217,7 @@ func TestGetHttpMethod_HeadMethod(t *testing.T) {
 
 func TestGetHttpMethod_GetMethod(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -237,7 +236,7 @@ func TestGetHttpMethod_GetMethod(t *testing.T) {
 
 func TestPrepareHealthCheck_NewEntry(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"

--- a/internal/kafka/handler.go
+++ b/internal/kafka/handler.go
@@ -6,13 +6,14 @@ package kafka
 
 import (
 	"encoding/json"
-	"fmt"
+	"pubsub-horizon-golaris/internal/config"
+	"strconv"
+
 	"github.com/IBM/sarama"
 	"github.com/burdiyan/kafkautil"
 	"github.com/rs/zerolog/log"
 	"github.com/telekom/pubsub-horizon-go/enum"
 	"github.com/telekom/pubsub-horizon-go/tracing"
-	"pubsub-horizon-golaris/internal/config"
 )
 
 var CurrentHandler HandlerInterface
@@ -44,8 +45,13 @@ func newKafkaHandler() (*Handler, error) {
 	}, nil
 }
 
-func (kafkaHandler Handler) RepublishMessage(traceCtx *tracing.TraceContext, message *sarama.ConsumerMessage, newDeliveryType string, newCallbackUrl string, errorParams bool) error {
-	var kafkaMessages = make([]*sarama.ProducerMessage, 0)
+func (kafkaHandler Handler) RepublishMessage(
+	traceCtx *tracing.TraceContext,
+	message *sarama.ConsumerMessage,
+	newDeliveryType, newCallbackUrl string,
+	errorParams bool,
+) error {
+	kafkaMessages := make([]*sarama.ProducerMessage, 0)
 
 	updatedMessage, err := updateMessage(message, newDeliveryType, newCallbackUrl)
 	if err != nil {
@@ -59,7 +65,7 @@ func (kafkaHandler Handler) RepublishMessage(traceCtx *tracing.TraceContext, mes
 		defer traceCtx.EndCurrentSpan()
 	}
 
-	if errorParams == true {
+	if errorParams {
 		optionalMetadataMessage, err := updateMetaData(message)
 		if err != nil {
 			log.Error().Err(err).Msg("Could not update message metadata")
@@ -77,11 +83,12 @@ func (kafkaHandler Handler) RepublishMessage(traceCtx *tracing.TraceContext, mes
 		return err
 	}
 
-	log.Debug().Msgf("Message with id %s sent to kafka: newDeliveryType %s newCallBackUrl %s", string(message.Key), newDeliveryType, newCallbackUrl)
+	log.Debug().
+		Msgf("Message with id %s sent to kafka: newDeliveryType %s newCallBackUrl %s", string(message.Key), newDeliveryType, newCallbackUrl)
 
 	if traceCtx != nil {
-		traceCtx.SetAttribute("partition", fmt.Sprintf("%d", updatedMessage.Partition))
-		traceCtx.SetAttribute("offset", fmt.Sprintf("%d", updatedMessage.Offset))
+		traceCtx.SetAttribute("partition", strconv.Itoa(int(updatedMessage.Partition)))
+		traceCtx.SetAttribute("offset", strconv.FormatInt(updatedMessage.Offset, 10))
 
 		log.Debug().Fields(map[string]any{
 			"uuid":      string(message.Key),
@@ -104,7 +111,7 @@ func copyHeaders(headers []*sarama.RecordHeader) []sarama.RecordHeader {
 	return newHeaders
 }
 
-func updateMessage(message *sarama.ConsumerMessage, newDeliveryType string, newCallbackUrl string) (*sarama.ProducerMessage, error) {
+func updateMessage(message *sarama.ConsumerMessage, newDeliveryType, newCallbackUrl string) (*sarama.ProducerMessage, error) {
 	var messageValue map[string]any
 	if err := json.Unmarshal(message.Value, &messageValue); err != nil {
 		log.Error().Err(err).Msg("Could not unmarshal message value")
@@ -162,7 +169,7 @@ func updateMetaData(message *sarama.ConsumerMessage) (*sarama.ProducerMessage, e
 		return nil, err
 	}
 
-	var metadataValue = map[string]any{
+	metadataValue := map[string]any{
 		"uuid": messageValue["uuid"],
 		"event": map[string]any{
 			"id": messageValue["event"].(map[string]any)["id"],

--- a/internal/kafka/handler_test.go
+++ b/internal/kafka/handler_test.go
@@ -6,10 +6,11 @@ package kafka
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/IBM/sarama"
 	"github.com/IBM/sarama/mocks"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 var mockHandler *Handler

--- a/internal/kafka/interfaces.go
+++ b/internal/kafka/interfaces.go
@@ -10,5 +10,10 @@ import (
 )
 
 type HandlerInterface interface {
-	RepublishMessage(traceCtx *tracing.TraceContext, message *sarama.ConsumerMessage, newDeliveryType string, newCallbackUrl string, errorParams bool) error
+	RepublishMessage(
+		traceCtx *tracing.TraceContext,
+		message *sarama.ConsumerMessage,
+		newDeliveryType, newCallbackUrl string,
+		errorParams bool,
+	) error
 }

--- a/internal/kafka/picker.go
+++ b/internal/kafka/picker.go
@@ -5,10 +5,11 @@
 package kafka
 
 import (
+	"pubsub-horizon-golaris/internal/config"
+
 	"github.com/IBM/sarama"
 	"github.com/rs/zerolog/log"
 	"github.com/telekom/pubsub-horizon-go/message"
-	"pubsub-horizon-golaris/internal/config"
 )
 
 type Picker struct {
@@ -21,7 +22,7 @@ type MessagePicker interface {
 }
 
 var NewPicker = func() (MessagePicker, error) {
-	var saramaConfig = sarama.NewConfig()
+	saramaConfig := sarama.NewConfig()
 	consumer, err := sarama.NewConsumer(config.Current.Kafka.Brokers, saramaConfig)
 	if err != nil {
 		return nil, err
@@ -36,7 +37,7 @@ func (p *Picker) Close() {
 }
 
 func (p *Picker) Pick(status *message.StatusMessage) (*sarama.ConsumerMessage, error) {
-	var partition, offset = *status.Coordinates.Partition, *status.Coordinates.Offset
+	partition, offset := *status.Coordinates.Partition, *status.Coordinates.Offset
 	partConsumer, err := p.consumer.ConsumePartition(status.Topic, partition, offset)
 	if err != nil {
 		return nil, err

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -44,7 +44,7 @@ func (sl *SubscriptionListener) OnAdd(event *hazelcast.EntryNotified, obj resour
 }
 
 // OnUpdate handles the subscription resource update event.
-func (sl *SubscriptionListener) OnUpdate(event *hazelcast.EntryNotified, obj resource.SubscriptionResource, oldObj resource.SubscriptionResource) {
+func (sl *SubscriptionListener) OnUpdate(event *hazelcast.EntryNotified, obj, oldObj resource.SubscriptionResource) {
 	subscriptionId := obj.Spec.Subscription.SubscriptionId
 	ctx := cache.HandlerCache.NewLockContext(context.Background())
 	lockKey := "listener:" + subscriptionId
@@ -55,19 +55,23 @@ func (sl *SubscriptionListener) OnUpdate(event *hazelcast.EntryNotified, obj res
 		logger.Debug().Msgf("Could not acquire listener lock for subscriptionId %s, skipping", subscriptionId)
 		return
 	}
-	defer cache.HandlerCache.Unlock(ctx, lockKey)
+	defer func() { _ = cache.HandlerCache.Unlock(ctx, lockKey) }()
 
-	if obj.Spec.Subscription.DeliveryType == "callback" && (oldObj.Spec.Subscription.DeliveryType == "sse" || oldObj.Spec.Subscription.DeliveryType == "server_sent_event") {
+	if obj.Spec.Subscription.DeliveryType == "callback" &&
+		(oldObj.Spec.Subscription.DeliveryType == "sse" || oldObj.Spec.Subscription.DeliveryType == "server_sent_event") {
+
 		handleDeliveryTypeChangeFromSSEToCallback(obj, oldObj)
 		return
 	}
 
-	if (obj.Spec.Subscription.DeliveryType == "sse" || obj.Spec.Subscription.DeliveryType == "server_sent_event") && oldObj.Spec.Subscription.DeliveryType == "callback" {
+	if (obj.Spec.Subscription.DeliveryType == "sse" || obj.Spec.Subscription.DeliveryType == "server_sent_event") &&
+		oldObj.Spec.Subscription.DeliveryType == "callback" {
+
 		handleDeliveryTypeChangeFromCallbackToSSE(obj, oldObj)
 		return
 	}
 
-	if obj.Spec.Subscription.CircuitBreakerOptOut == true && oldObj.Spec.Subscription.CircuitBreakerOptOut != true {
+	if obj.Spec.Subscription.CircuitBreakerOptOut && !oldObj.Spec.Subscription.CircuitBreakerOptOut {
 		handleCircuitBreakerOptOutChange(obj, oldObj)
 		return
 	}
@@ -100,7 +104,7 @@ func (sl *SubscriptionListener) OnDelete(event *hazelcast.EntryNotified) {
 		logger.Debug().Msgf("Could not acquire listener lock for subscriptionId %s on OnDelete, skipping", key)
 		return
 	}
-	defer cache.HandlerCache.Unlock(ctx, lockKey)
+	defer func() { _ = cache.HandlerCache.Unlock(ctx, lockKey) }()
 
 	optionalEntry, err := cache.RepublishingCache.Get(context.Background(), key)
 	if err != nil {
@@ -129,16 +133,19 @@ func (sl *SubscriptionListener) OnError(event *hazelcast.EntryNotified, err erro
 }
 
 // handleDeliveryTypeChange reacts to changes for the deliveryType of subscriptions.
-// If delivery type changes from sse to callback, sets a new entry in RepublishingCache and store the old delivery type.
-// When republishing, the old deliveryType is used to check whether old SSE events that are set to PROCESSED still need to be republished.
-// If delivery type changes from callback to sse, deletes existing entry in RepublishingCache if present and sets a new entry without storing the old delivery type.
-// Delete the HealthCheckCacheEntry and close the circuitBreaker, because it is no longer needed for sse.
-func handleDeliveryTypeChangeFromSSEToCallback(obj resource.SubscriptionResource, oldObj resource.SubscriptionResource) {
+// If delivery type changes from sse to callback, sets a new entry in RepublishingCache
+// and store the old delivery type. When republishing, the old deliveryType is used to
+// check whether old SSE events that are set to PROCESSED still need to be republished.
+// If delivery type changes from callback to sse, deletes existing entry in
+// RepublishingCache if present and sets a new entry without storing the old delivery
+// type. Delete the HealthCheckCacheEntry and close the circuitBreaker, because it is
+// no longer needed for sse.
+func handleDeliveryTypeChangeFromSSEToCallback(obj, oldObj resource.SubscriptionResource) {
 	logger.Debug().Msgf("Delivery type changed from sse to callback for subscription %s", obj.Spec.Subscription.SubscriptionId)
-	setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, string(oldObj.Spec.Subscription.DeliveryType), false)
+	setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, string(oldObj.Spec.Subscription.DeliveryType))
 }
 
-func handleDeliveryTypeChangeFromCallbackToSSE(obj resource.SubscriptionResource, oldObj resource.SubscriptionResource) {
+func handleDeliveryTypeChangeFromCallbackToSSE(obj, oldObj resource.SubscriptionResource) {
 	logger.Debug().Msgf("Delivery type changed from callback to sse for subscription %s", obj.Spec.Subscription.SubscriptionId)
 	optionalEntry, err := cache.RepublishingCache.Get(context.Background(), obj.Spec.Subscription.SubscriptionId)
 	if err != nil {
@@ -148,11 +155,18 @@ func handleDeliveryTypeChangeFromCallbackToSSE(obj resource.SubscriptionResource
 
 	if optionalEntry != nil {
 		if err := republish.ForceDelete(context.Background(), obj.Spec.Subscription.SubscriptionId); err != nil {
-			logger.Error().Err(err).Msgf("Failed to delete republishing cache entry for subscriptionId %s on handleDeliveryTypeChangeFromCallbackToSSE", obj.Spec.Subscription.SubscriptionId)
+			logger.Error().
+				Err(err).
+				Msgf("Failed to delete republishing cache entry for subscriptionId %s "+
+					"on handleDeliveryTypeChangeFromCallbackToSSE",
+					obj.Spec.Subscription.SubscriptionId)
 			return
 		}
 
-		logger.Debug().Msgf("Waiting for 2 seconds before setting new entry to RepublishingCache for subscription %s", obj.Spec.Subscription.SubscriptionId)
+		logger.Debug().
+			Msgf("Waiting for 2 seconds before setting new entry to "+
+				"RepublishingCache for subscription %s",
+				obj.Spec.Subscription.SubscriptionId)
 
 		// We need to wait for the goroutine to finish before setting a new entry in the republishing cache
 		time.Sleep(2 * time.Second)
@@ -170,13 +184,17 @@ func handleDeliveryTypeChangeFromCallbackToSSE(obj resource.SubscriptionResource
 		circuitbreaker.CloseCircuitBreaker(cbMessage)
 	}
 
-	setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, string(oldObj.Spec.Subscription.DeliveryType), false)
+	setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, string(oldObj.Spec.Subscription.DeliveryType))
 }
 
 // handleCallbackUrlChange reacts to changes for the callback URL of subscriptions.
 // If callback URL changes and an entry exists in RepublishingCache, deletes the existing entry and sets a new one.
-func handleCallbackUrlChange(obj resource.SubscriptionResource, oldObj resource.SubscriptionResource) {
-	logger.Debug().Msgf("Callback URL changed from %s to %s for subscription %s", oldObj.Spec.Subscription.Callback, obj.Spec.Subscription.Callback, obj.Spec.Subscription.SubscriptionId)
+func handleCallbackUrlChange(obj, oldObj resource.SubscriptionResource) {
+	logger.Debug().
+		Msgf("Callback URL changed from %s to %s for subscription %s",
+			oldObj.Spec.Subscription.Callback,
+			obj.Spec.Subscription.Callback,
+			obj.Spec.Subscription.SubscriptionId)
 	optionalEntry, err := cache.RepublishingCache.Get(context.Background(), obj.Spec.Subscription.SubscriptionId)
 	if err != nil {
 		logger.Error().Err(err).Msgf("Failed to get republishing cache entry for subscription %s", obj.Spec.Subscription.SubscriptionId)
@@ -185,26 +203,36 @@ func handleCallbackUrlChange(obj resource.SubscriptionResource, oldObj resource.
 
 	if optionalEntry != nil {
 		if err := republish.ForceDelete(context.Background(), obj.Spec.Subscription.SubscriptionId); err != nil {
-			logger.Error().Err(err).Msgf("Failed to delete republishing cache entry for subscriptionId %s on handleCallbackUrlChange", obj.Spec.Subscription.SubscriptionId)
+			logger.Error().
+				Err(err).
+				Msgf("Failed to delete republishing cache entry for subscriptionId %s "+
+					"on handleCallbackUrlChange", obj.Spec.Subscription.SubscriptionId)
 			return
 		}
 
 		logger.Debug().Msgf("Successfully deleted RepublishingCache entry for subscriptionId %s", obj.Spec.Subscription.SubscriptionId)
-		logger.Debug().Msgf("Waiting for 2 seconds before setting new entry to RepublishingCache for subscription %s", obj.Spec.Subscription.SubscriptionId)
+		logger.Debug().
+			Msgf("Waiting for 2 seconds before setting new entry to "+
+				"RepublishingCache for subscription %s",
+				obj.Spec.Subscription.SubscriptionId)
 
 		// We need to wait for the goroutine to finish before setting a new entry in the republishing cache
 		time.Sleep(2 * time.Second)
 
 		logger.Info().Msgf("Start to set new entry to RepublishingCache for subscription %s", obj.Spec.Subscription.SubscriptionId)
-		setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, "", false)
+		setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, "")
 	}
 }
 
 // handleCircuitBreakerOptOutChange reacts to changes for CircuitBreakerOptOut flag of subscriptions.
 // If the flag is set to true and an entry exists in RepublishingCache, close circuitBreaker,
 // add new entry in the republishingCache and deletes health checks.
-func handleCircuitBreakerOptOutChange(obj resource.SubscriptionResource, oldObj resource.SubscriptionResource) {
-	logger.Debug().Msgf("CircuitBreakerOptOut changed from %v to %v for subscription %s", oldObj.Spec.Subscription.CircuitBreakerOptOut, obj.Spec.Subscription.CircuitBreakerOptOut, obj.Spec.Subscription.SubscriptionId)
+func handleCircuitBreakerOptOutChange(obj, oldObj resource.SubscriptionResource) {
+	logger.Debug().
+		Msgf("CircuitBreakerOptOut changed from %v to %v for subscription %s",
+			oldObj.Spec.Subscription.CircuitBreakerOptOut,
+			obj.Spec.Subscription.CircuitBreakerOptOut,
+			obj.Spec.Subscription.SubscriptionId)
 	optionalEntry, err := cache.RepublishingCache.Get(context.Background(), obj.Spec.Subscription.SubscriptionId)
 	if err != nil {
 		logger.Error().Msgf("Failed to get republishing cache entry for subscription %s: %v", obj.Spec.Subscription.SubscriptionId, err)
@@ -213,13 +241,20 @@ func handleCircuitBreakerOptOutChange(obj resource.SubscriptionResource, oldObj 
 
 	if optionalEntry != nil {
 		if err := republish.ForceDelete(context.Background(), obj.Spec.Subscription.SubscriptionId); err != nil {
-			logger.Error().Err(err).Msgf("Failed to delete republishing cache entry for subscriptionId %s on handleCircuitBreakerOptOutChange", obj.Spec.Subscription.SubscriptionId)
+			logger.Error().
+				Err(err).
+				Msgf("Failed to delete republishing cache entry for subscriptionId %s "+
+					"on handleCircuitBreakerOptOutChange",
+					obj.Spec.Subscription.SubscriptionId)
 			return
 		}
 
 		logger.Debug().Msgf("Successfully deleted RepublishingCache entry for subscriptionId %s", obj.Spec.Subscription.SubscriptionId)
 
-		logger.Debug().Msgf("Waiting for 2 seconds before setting new entry to RepublishingCache for subscription %s", obj.Spec.Subscription.SubscriptionId)
+		logger.Debug().
+			Msgf("Waiting for 2 seconds before setting new entry to "+
+				"RepublishingCache for subscription %s",
+				obj.Spec.Subscription.SubscriptionId)
 
 		// We need to wait for the goroutine to finish before setting a new entry in the republishing cache
 		time.Sleep(2 * time.Second)
@@ -236,11 +271,15 @@ func handleCircuitBreakerOptOutChange(obj resource.SubscriptionResource, oldObj 
 	}
 
 	logger.Info().Msgf("Start to set new entry to RepublishingCache for subscription %s", obj.Spec.Subscription.SubscriptionId)
-	setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, "", false)
+	setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, "")
 }
 
-func handleRedeliveriesPerSecondChange(obj resource.SubscriptionResource, oldObj resource.SubscriptionResource) {
-	logger.Debug().Msgf("RedeliveriesPerSecond changed from %v to %v for subscription %s", oldObj.Spec.Subscription.RedeliveriesPerSecond, obj.Spec.Subscription.RedeliveriesPerSecond, obj.Spec.Subscription.SubscriptionId)
+func handleRedeliveriesPerSecondChange(obj, oldObj resource.SubscriptionResource) {
+	logger.Debug().
+		Msgf("RedeliveriesPerSecond changed from %v to %v for subscription %s",
+			oldObj.Spec.Subscription.RedeliveriesPerSecond,
+			obj.Spec.Subscription.RedeliveriesPerSecond,
+			obj.Spec.Subscription.SubscriptionId)
 	optionalEntry, err := cache.RepublishingCache.Get(context.Background(), obj.Spec.Subscription.SubscriptionId)
 	if err != nil {
 		logger.Error().Msgf("Failed to get republishing cache entry for subscription %s: %v", obj.Spec.Subscription.SubscriptionId, err)
@@ -249,23 +288,30 @@ func handleRedeliveriesPerSecondChange(obj resource.SubscriptionResource, oldObj
 
 	if optionalEntry != nil {
 		if err := republish.ForceDelete(context.Background(), obj.Spec.Subscription.SubscriptionId); err != nil {
-			logger.Error().Err(err).Msgf("Failed to delete republishing cache entry for subscriptionId %s on handleRedeliveriesPerSecondChange", obj.Spec.Subscription.SubscriptionId)
+			logger.Error().
+				Err(err).
+				Msgf("Failed to delete republishing cache entry for subscriptionId %s "+
+					"on handleRedeliveriesPerSecondChange",
+					obj.Spec.Subscription.SubscriptionId)
 			return
 		}
 
 		logger.Debug().Msgf("Successfully deleted RepublishingCache entry for subscriptionId %s", obj.Spec.Subscription.SubscriptionId)
 
-		logger.Debug().Msgf("Waiting for 2 seconds before setting new entry to RepublishingCache for subscription %s", obj.Spec.Subscription.SubscriptionId)
+		logger.Debug().
+			Msgf("Waiting for 2 seconds before setting new entry to "+
+				"RepublishingCache for subscription %s",
+				obj.Spec.Subscription.SubscriptionId)
 
 		// We need to wait for the goroutine to finish before setting a new entry in the republishing cache
 		time.Sleep(2 * time.Second)
 
 		logger.Info().Msgf("Start to set new entry to RepublishingCache for subscription %s", obj.Spec.Subscription.SubscriptionId)
-		setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, "", false)
+		setNewEntryToRepublishingCache(obj.Spec.Subscription.SubscriptionId, "")
 	}
 }
 
-func setNewEntryToRepublishingCache(subscriptionId string, oldDeliveryType string, subscriptionChange bool) {
+func setNewEntryToRepublishingCache(subscriptionId, oldDeliveryType string) {
 	// If circuit breaker is open, do not set republishing cache entry to avoid a republishing loop
 	if cbEntry, err := cache.CircuitBreakerCache.Get(config.Current.Hazelcast.Caches.CircuitBreakerCache, subscriptionId); err != nil {
 		logger.Error().Msgf("Failed to get circuit breaker cache entry for subscription %s: %v", subscriptionId, err)
@@ -280,7 +326,7 @@ func setNewEntryToRepublishingCache(subscriptionId string, oldDeliveryType strin
 		OldDeliveryType:    oldDeliveryType,
 		RepublishingUpTo:   time.Now(),
 		PostponedUntil:     time.Now(),
-		SubscriptionChange: subscriptionChange,
+		SubscriptionChange: false,
 	}); err != nil {
 		logger.Error().Msgf("Failed to set republishing cache for subscription %s: %v", subscriptionId, err)
 	}

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -6,7 +6,7 @@ package listener
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/republish"
@@ -20,7 +20,12 @@ import (
 	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
-func createSubscriptionResource(subscriptionId, deliveryType string, circuitBreaker bool, callbackUrl string, redeliveriesPerSecond int) *resource.SubscriptionResource {
+func createSubscriptionResource(
+	subscriptionId, deliveryType string,
+	circuitBreaker bool,
+	callbackUrl string,
+	redeliveriesPerSecond int,
+) *resource.SubscriptionResource {
 	return &resource.SubscriptionResource{
 		Spec: struct {
 			Subscription resource.Subscription `json:"subscription"`
@@ -52,7 +57,6 @@ func setupMocks() (*test.RepublishingMockMap, *test.CircuitBreakerMockCache) {
 	cache.HandlerCache = handlerCache
 
 	return republishMockMap, circuitBreakerCache
-
 }
 
 func Test_InitializeListener(t *testing.T) {
@@ -327,7 +331,7 @@ func TestSubscriptionListener_OnDelete_CBCleanupProceedsWhenRepublishingFails(t 
 	republishMockMap, circuitBreakerCache := setupMocks()
 
 	// Republishing cache Get fails
-	republishMockMap.On("Get", mock.Anything, subscriptionId).Return(nil, fmt.Errorf("hazelcast connection error"))
+	republishMockMap.On("Get", mock.Anything, subscriptionId).Return(nil, errors.New("hazelcast connection error"))
 
 	// Circuit breaker exists and should still be cleaned up
 	cbMessage := &message.CircuitBreakerMessage{

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -5,10 +5,11 @@
 package log
 
 import (
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 	"os"
 	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 func SetLogLevel(level string) {
@@ -21,6 +22,8 @@ func SetLogLevel(level string) {
 	zerolog.TimeFieldFormat = time.RFC3339 // Set the time format to RFC3339 which includes seconds
 	log.Logger = zerolog.New(os.Stdout).Level(logLevel).With().Timestamp().Logger()
 	if logLevel == zerolog.DebugLevel {
-		log.Logger = log.Logger.Output(zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}) // Set the time format for the console writer as well
+		log.Logger = log.Logger.Output(
+			zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339},
+		) // Set the time format for the console writer as well
 	}
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -6,10 +6,11 @@ package log
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestSetValidLogLevel(t *testing.T) {

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -15,21 +15,21 @@ import (
 type CircuitBreakerListener struct{}
 
 func (c *CircuitBreakerListener) OnAdd(event *hazelcast.EntryNotified, obj message.CircuitBreakerMessage) {
-	var open = obj.Status == enum.CircuitBreakerStatusOpen
-	var subscriptionId = event.Key.(string)
-	var subscriberId = lookupSubscriberId(subscriptionId)
+	open := obj.Status == enum.CircuitBreakerStatusOpen
+	subscriptionId := event.Key.(string)
+	subscriberId := lookupSubscriberId(subscriptionId)
 	recordCircuitBreaker(subscriptionId, subscriberId, obj.EventType, obj.Environment, open)
 }
 
-func (c *CircuitBreakerListener) OnUpdate(event *hazelcast.EntryNotified, obj message.CircuitBreakerMessage, oldObj message.CircuitBreakerMessage) {
-	var open = obj.Status == enum.CircuitBreakerStatusOpen
-	var subscriptionId = event.Key.(string)
-	var subscriberId = lookupSubscriberId(subscriptionId)
+func (c *CircuitBreakerListener) OnUpdate(event *hazelcast.EntryNotified, obj, oldObj message.CircuitBreakerMessage) {
+	open := obj.Status == enum.CircuitBreakerStatusOpen
+	subscriptionId := event.Key.(string)
+	subscriberId := lookupSubscriberId(subscriptionId)
 	recordCircuitBreaker(subscriptionId, subscriberId, obj.EventType, obj.Environment, open)
 }
 
 func (c *CircuitBreakerListener) OnDelete(event *hazelcast.EntryNotified) {
-	var subscriptionId = event.Key.(string)
+	subscriptionId := event.Key.(string)
 	openCircuitBreakers.DeletePartialMatch(prometheus.Labels{
 		"subscriptionId": subscriptionId,
 	})

--- a/internal/metrics/listener.go
+++ b/internal/metrics/listener.go
@@ -31,7 +31,7 @@ func (c *CircuitBreakerListener) OnUpdate(event *hazelcast.EntryNotified, obj, o
 func (c *CircuitBreakerListener) OnDelete(event *hazelcast.EntryNotified) {
 	subscriptionId := event.Key.(string)
 	openCircuitBreakers.DeletePartialMatch(prometheus.Labels{
-		"subscriptionId": subscriptionId,
+		labelSubscriptionId: subscriptionId,
 	})
 }
 

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -21,14 +21,21 @@ var (
 	registry *prometheus.Registry
 )
 
-const namespace = "golaris"
+const (
+	namespace = "golaris"
+
+	labelSubscriptionId = "subscriptionId"
+	labelSubscriberId   = "subscriberId"
+	labelEventType      = "eventType"
+	labelEnvironment    = "environment"
+)
 
 func init() {
 	openCircuitBreakers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "open_circuit_breakers",
 		Help:      "The amount of open circuit-breakers.",
 		Namespace: namespace,
-	}, []string{"subscriptionId", "subscriberId", "eventType", "environment"})
+	}, []string{labelSubscriptionId, labelSubscriberId, labelEventType, labelEnvironment})
 
 	registry = prometheus.NewRegistry()
 	registry.MustRegister(openCircuitBreakers)
@@ -38,10 +45,10 @@ func recordCircuitBreaker(subscriptionId, subscriberId, eventType, environment s
 	if config.Current.Metrics.Enabled {
 		value := float64(utils.IfThenElse(open, 1, 0))
 		openCircuitBreakers.With(map[string]string{
-			"subscriptionId": subscriptionId,
-			"subscriberId":   subscriberId,
-			"eventType":      eventType,
-			"environment":    environment,
+			labelSubscriptionId: subscriptionId,
+			labelSubscriberId:   subscriberId,
+			labelEventType:      eventType,
+			labelEnvironment:    environment,
 		}).Set(value)
 	}
 }
@@ -65,7 +72,7 @@ func PopulateFromCache() {
 func lookupSubscriberId(subscriptionId string) string {
 	subscription, err := cache.SubscriptionCache.Get(config.Current.Hazelcast.Caches.SubscriptionCache, subscriptionId)
 	if err != nil || subscription == nil {
-		log.Warn().Str("subscriptionId", subscriptionId).Msg("could not look up subscriberId for metric")
+		log.Warn().Str(labelSubscriptionId, subscriptionId).Msg("could not look up subscriberId for metric")
 		return "unknown"
 	}
 	return subscription.Spec.Subscription.SubscriberId

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -5,13 +5,14 @@
 package metrics
 
 import (
+	"pubsub-horizon-golaris/internal/cache"
+	"pubsub-horizon-golaris/internal/config"
+	"pubsub-horizon-golaris/internal/utils"
+
 	"github.com/hazelcast/hazelcast-go-client/predicate"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog/log"
 	"github.com/telekom/pubsub-horizon-go/enum"
-	"pubsub-horizon-golaris/internal/cache"
-	"pubsub-horizon-golaris/internal/config"
-	"pubsub-horizon-golaris/internal/utils"
 )
 
 var (
@@ -33,9 +34,9 @@ func init() {
 	registry.MustRegister(openCircuitBreakers)
 }
 
-func recordCircuitBreaker(subscriptionId string, subscriberId string, eventType string, environment string, open bool) {
+func recordCircuitBreaker(subscriptionId, subscriberId, eventType, environment string, open bool) {
 	if config.Current.Metrics.Enabled {
-		var value = float64(utils.IfThenElse(open, 1, 0))
+		value := float64(utils.IfThenElse(open, 1, 0))
 		openCircuitBreakers.With(map[string]string{
 			"subscriptionId": subscriptionId,
 			"subscriberId":   subscriberId,
@@ -46,14 +47,17 @@ func recordCircuitBreaker(subscriptionId string, subscriberId string, eventType 
 }
 
 func PopulateFromCache() {
-	var cbc = cache.CircuitBreakerCache
-	circuitBreakers, err := cbc.GetQuery(config.Current.Hazelcast.Caches.CircuitBreakerCache, predicate.Equal("status", string(enum.CircuitBreakerStatusOpen)))
+	cbc := cache.CircuitBreakerCache
+	circuitBreakers, err := cbc.GetQuery(
+		config.Current.Hazelcast.Caches.CircuitBreakerCache,
+		predicate.Equal("status", string(enum.CircuitBreakerStatusOpen)),
+	)
 	if err != nil {
 		log.Warn().Err(err).Msg("could initialize metrics from circuit-breakers map")
 	}
 
 	for _, circuitBreaker := range circuitBreakers {
-		var subscriberId = lookupSubscriberId(circuitBreaker.SubscriptionId)
+		subscriberId := lookupSubscriberId(circuitBreaker.SubscriptionId)
 		recordCircuitBreaker(circuitBreaker.SubscriptionId, subscriberId, circuitBreaker.EventType, circuitBreaker.Environment, true)
 	}
 }
@@ -68,8 +72,8 @@ func lookupSubscriberId(subscriptionId string) string {
 }
 
 func ListenForChanges() {
-	var cbc = cache.CircuitBreakerCache
-	var listener = new(CircuitBreakerListener)
+	cbc := cache.CircuitBreakerCache
+	listener := new(CircuitBreakerListener)
 	if err := cbc.AddListener(config.Current.Hazelcast.Caches.CircuitBreakerCache, listener); err != nil {
 		log.Warn().Err(err).Msg("could not register listener for circuit-breakers map")
 	}

--- a/internal/metrics/registry_test.go
+++ b/internal/metrics/registry_test.go
@@ -30,6 +30,7 @@ func resetMetrics() {
 	registry.MustRegister(openCircuitBreakers)
 }
 
+//nolint:gocognit // test setup with multiple assertions
 func TestPopulateFromCache_OnlyOpenCircuitBreakers(t *testing.T) {
 	resetMetrics()
 	config.Current = test.BuildTestConfig()

--- a/internal/mongo/connection.go
+++ b/internal/mongo/connection.go
@@ -6,10 +6,11 @@ package mongo
 
 import (
 	"context"
+	"pubsub-horizon-golaris/internal/config"
+
 	"github.com/rs/zerolog/log"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"pubsub-horizon-golaris/internal/config"
 )
 
 var CurrentConnection HandlerInterface

--- a/internal/mongo/interfaces.go
+++ b/internal/mongo/interfaces.go
@@ -5,8 +5,9 @@
 package mongo
 
 import (
-	"github.com/telekom/pubsub-horizon-go/message"
 	"time"
+
+	"github.com/telekom/pubsub-horizon-go/message"
 )
 
 type HandlerInterface interface {
@@ -14,5 +15,5 @@ type HandlerInterface interface {
 	FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error)
 	FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error)
 	FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error)
-	FindDistinctSubscriptionsForWaitingEvents(beginTimestamp time.Time, endTimestamp time.Time) ([]string, error)
+	FindDistinctSubscriptionsForWaitingEvents(beginTimestamp, endTimestamp time.Time) ([]string, error)
 }

--- a/internal/mongo/query.go
+++ b/internal/mongo/query.go
@@ -16,6 +16,14 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const (
+	fieldStatus         = "status"
+	fieldDeliveryType   = "deliveryType"
+	fieldModified       = "modified"
+	fieldSubscriptionId = "subscriptionId"
+	opLte               = "$lte"
+)
+
 func (connection Connection) findMessagesByQuery(query bson.M, lastTimestamp any) ([]message.StatusMessage, any, error) {
 	batchSize := config.Current.Republishing.BatchSize
 	ctx := context.Background()
@@ -69,15 +77,15 @@ func (connection Connection) distinctFieldByQuery(query bson.M, fieldName string
 
 func (connection Connection) FindDistinctSubscriptionsForWaitingEvents(beginTimestamp, endTimestamp time.Time) ([]string, error) {
 	query := bson.M{
-		"status":       "WAITING",
-		"deliveryType": "CALLBACK",
-		"modified": bson.M{
+		fieldStatus:       "WAITING",
+		fieldDeliveryType: "CALLBACK",
+		fieldModified: bson.M{
 			"$gte": beginTimestamp,
-			"$lte": endTimestamp,
+			opLte:  endTimestamp,
 		},
 	}
 
-	subscriptions, err := connection.distinctFieldByQuery(query, "subscriptionId")
+	subscriptions, err := connection.distinctFieldByQuery(query, fieldSubscriptionId)
 	if err != nil {
 		return nil, err
 	}
@@ -96,10 +104,10 @@ func (connection Connection) FindWaitingMessages(
 	subscriptionId string,
 ) ([]message.StatusMessage, any, error) {
 	query := bson.M{
-		"status":         "WAITING",
-		"subscriptionId": subscriptionId,
-		"modified": bson.M{
-			"$lte": timestamp,
+		fieldStatus:         "WAITING",
+		fieldSubscriptionId: subscriptionId,
+		fieldModified: bson.M{
+			opLte: timestamp,
 		},
 	}
 
@@ -112,11 +120,11 @@ func (connection Connection) FindProcessedMessagesByDeliveryTypeSSE(
 	subscriptionId string,
 ) ([]message.StatusMessage, any, error) {
 	query := bson.M{
-		"status":         "PROCESSED",
-		"deliveryType":   "SERVER_SENT_EVENT",
-		"subscriptionId": subscriptionId,
-		"modified": bson.M{
-			"$lte": timestamp,
+		fieldStatus:         "PROCESSED",
+		fieldDeliveryType:   "SERVER_SENT_EVENT",
+		fieldSubscriptionId: subscriptionId,
+		fieldModified: bson.M{
+			opLte: timestamp,
 		},
 	}
 
@@ -128,9 +136,9 @@ func (connection Connection) FindDeliveringMessagesByDeliveryType(
 	lastTimestamp any,
 ) ([]message.StatusMessage, any, error) {
 	query := bson.M{
-		"status": "DELIVERING",
-		"modified": bson.M{
-			"$lte": timestamp,
+		fieldStatus: "DELIVERING",
+		fieldModified: bson.M{
+			opLte: timestamp,
 		},
 	}
 
@@ -142,10 +150,10 @@ func (connection Connection) FindFailedMessagesWithCallbackUrlNotFoundException(
 	lastTimestamp any,
 ) ([]message.StatusMessage, any, error) {
 	query := bson.M{
-		"status":    "FAILED",
+		fieldStatus: "FAILED",
 		"errorType": "de.telekom.horizon.comet.exception.CallbackUrlNotFoundException",
-		"modified": bson.M{
-			"$lte": timestamp,
+		fieldModified: bson.M{
+			opLte: timestamp,
 		},
 	}
 

--- a/internal/mongo/query.go
+++ b/internal/mongo/query.go
@@ -7,17 +7,18 @@ package mongo
 import (
 	"context"
 	"fmt"
+	"pubsub-horizon-golaris/internal/config"
+	"time"
+
 	"github.com/rs/zerolog/log"
 	"github.com/telekom/pubsub-horizon-go/message"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"pubsub-horizon-golaris/internal/config"
-	"time"
 )
 
 func (connection Connection) findMessagesByQuery(query bson.M, lastTimestamp any) ([]message.StatusMessage, any, error) {
-	var batchSize = config.Current.Republishing.BatchSize
-	var ctx = context.Background()
+	batchSize := config.Current.Republishing.BatchSize
+	ctx := context.Background()
 
 	opts := options.Find().
 		SetLimit(batchSize).
@@ -53,7 +54,6 @@ func (connection Connection) findMessagesByQuery(query bson.M, lastTimestamp any
 }
 
 func (connection Connection) distinctFieldByQuery(query bson.M, fieldName string) ([]interface{}, error) {
-
 	opts := options.Distinct()
 
 	collection := connection.Client.Database(connection.Config.Database).Collection(connection.Config.Collection)
@@ -67,7 +67,7 @@ func (connection Connection) distinctFieldByQuery(query bson.M, fieldName string
 	return fields, nil
 }
 
-func (connection Connection) FindDistinctSubscriptionsForWaitingEvents(beginTimestamp time.Time, endTimestamp time.Time) ([]string, error) {
+func (connection Connection) FindDistinctSubscriptionsForWaitingEvents(beginTimestamp, endTimestamp time.Time) ([]string, error) {
 	query := bson.M{
 		"status":       "WAITING",
 		"deliveryType": "CALLBACK",
@@ -90,7 +90,11 @@ func (connection Connection) FindDistinctSubscriptionsForWaitingEvents(beginTime
 	return castedSubscriptions, err
 }
 
-func (connection Connection) FindWaitingMessages(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindWaitingMessages(
+	timestamp time.Time,
+	lastTimestamp any,
+	subscriptionId string,
+) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status":         "WAITING",
 		"subscriptionId": subscriptionId,
@@ -102,7 +106,11 @@ func (connection Connection) FindWaitingMessages(timestamp time.Time, lastTimest
 	return connection.findMessagesByQuery(query, lastTimestamp)
 }
 
-func (connection Connection) FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindProcessedMessagesByDeliveryTypeSSE(
+	timestamp time.Time,
+	lastTimestamp any,
+	subscriptionId string,
+) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status":         "PROCESSED",
 		"deliveryType":   "SERVER_SENT_EVENT",
@@ -115,7 +123,10 @@ func (connection Connection) FindProcessedMessagesByDeliveryTypeSSE(timestamp ti
 	return connection.findMessagesByQuery(query, lastTimestamp)
 }
 
-func (connection Connection) FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindDeliveringMessagesByDeliveryType(
+	timestamp time.Time,
+	lastTimestamp any,
+) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status": "DELIVERING",
 		"modified": bson.M{
@@ -126,7 +137,10 @@ func (connection Connection) FindDeliveringMessagesByDeliveryType(timestamp time
 	return connection.findMessagesByQuery(query, lastTimestamp)
 }
 
-func (connection Connection) FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
+func (connection Connection) FindFailedMessagesWithCallbackUrlNotFoundException(
+	timestamp time.Time,
+	lastTimestamp any,
+) ([]message.StatusMessage, any, error) {
 	query := bson.M{
 		"status":    "FAILED",
 		"errorType": "de.telekom.horizon.comet.exception.CallbackUrlNotFoundException",

--- a/internal/mongo/query_test.go
+++ b/internal/mongo/query_test.go
@@ -5,15 +5,16 @@
 package mongo
 
 import (
+	"pubsub-horizon-golaris/internal/config"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/telekom/pubsub-horizon-go/enum"
 	"github.com/telekom/pubsub-horizon-go/message"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/integration/mtest"
-	"pubsub-horizon-golaris/internal/config"
-	"testing"
-	"time"
 )
 
 func TestConnection_FindWaitingMessages(t *testing.T) {
@@ -34,8 +35,8 @@ func TestConnection_FindWaitingMessages(t *testing.T) {
 		}
 
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, "testdb.testcollection", mtest.FirstBatch, bson.D{
-			{"status", expectedMessage.Status},
-			{"subscriptionId", expectedMessage.SubscriptionId},
+			{Key: "status", Value: expectedMessage.Status},
+			{Key: "subscriptionId", Value: expectedMessage.SubscriptionId},
 		}))
 
 		messages, _, err := connection.FindWaitingMessages(time.Now(), expectedMessage.SubscriptionId, mock.Anything)
@@ -64,9 +65,9 @@ func TestConnection_FindDeliveringMessagesByDeliveryType(t *testing.T) {
 		}
 
 		mt.AddMockResponses(mtest.CreateCursorResponse(0, "testdb.testcollection", mtest.FirstBatch, bson.D{
-			{"status", expectedMessage.Status},
-			{"deliveryType", expectedMessage.DeliveryType},
-			{"subscriptionId", expectedMessage.SubscriptionId},
+			{Key: "status", Value: expectedMessage.Status},
+			{Key: "deliveryType", Value: expectedMessage.DeliveryType},
+			{Key: "subscriptionId", Value: expectedMessage.SubscriptionId},
 		}))
 
 		messages, _, err := connection.FindDeliveringMessagesByDeliveryType(time.Now(), mock.Anything)
@@ -76,7 +77,5 @@ func TestConnection_FindDeliveringMessagesByDeliveryType(t *testing.T) {
 		assert.Equal(t, expectedMessage.Status, messages[0].Status)
 		assert.Equal(t, expectedMessage.DeliveryType, messages[0].DeliveryType)
 		assert.Equal(t, expectedMessage.SubscriptionId, messages[0].SubscriptionId)
-
 	})
-
 }

--- a/internal/mongo/types.go
+++ b/internal/mongo/types.go
@@ -5,8 +5,9 @@
 package mongo
 
 import (
-	"go.mongodb.org/mongo-driver/mongo"
 	"pubsub-horizon-golaris/internal/config"
+
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Connection struct {

--- a/internal/notify/listener.go
+++ b/internal/notify/listener.go
@@ -45,7 +45,7 @@ func (n NotificationListener) OnAdd(event *hazelcast.EntryNotified, obj message.
 	}
 }
 
-func (n NotificationListener) OnUpdate(event *hazelcast.EntryNotified, obj message.CircuitBreakerMessage, oldObj message.CircuitBreakerMessage) {
+func (n NotificationListener) OnUpdate(event *hazelcast.EntryNotified, obj, oldObj message.CircuitBreakerMessage) {
 	notificationConfig := config.Current.Notifications
 	circuitBreakerOpen := obj.Status == enum.CircuitBreakerStatusOpen
 
@@ -113,7 +113,7 @@ func (n NotificationListener) lockKey(key any, action string, leaseDuration time
 	}
 }
 
-func notifyConsumer(cbMessage *message.CircuitBreakerMessage, subject string, template string) error {
+func notifyConsumer(cbMessage *message.CircuitBreakerMessage, subject, template string) error {
 	log.Debug().
 		Str("subscriptionId", cbMessage.SubscriptionId).
 		Msg("Sending notification for open circuit-breaker")

--- a/internal/notify/listener.go
+++ b/internal/notify/listener.go
@@ -19,6 +19,7 @@ import (
 	"github.com/telekom/galileo-client-go/options"
 	"github.com/telekom/pubsub-horizon-go/enum"
 	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
 type NotificationListener struct{}
@@ -122,49 +123,60 @@ func notifyConsumer(cbMessage *message.CircuitBreakerMessage, subject, template 
 		return err
 	}
 
-	if subscription != nil {
-		label, ok := subscription.Metadata.Annotations["ei.telekom.de/origin.namespace"].(string)
+	if subscription == nil {
+		return nil
+	}
 
-		if ok {
-			mailConfig := config.Current.Notifications.Mail
+	label, ok := subscription.Metadata.Annotations["ei.telekom.de/origin.namespace"].(string)
+	if !ok {
+		return nil
+	}
 
-			callbackUrlParts := strings.SplitN(subscription.Spec.Subscription.Callback, "url=", 2)
-			callbackUrl := utils.IfThenElse(len(callbackUrlParts) > 1, callbackUrlParts[1], callbackUrlParts[0])
+	return sendNotification(cbMessage, subscription, label, subject, template)
+}
 
-			subject := utils.ReplaceWithMap(subject, map[string]string{
-				"$environment": cbMessage.Environment,
-				"$application": strings.Replace(subscription.Spec.Subscription.SubscriberId, label+"--", "", 1),
-			})
+func sendNotification(
+	cbMessage *message.CircuitBreakerMessage,
+	subscription *resource.SubscriptionResource,
+	label, subject, template string,
+) error {
+	mailConfig := config.Current.Notifications.Mail
 
-			if cbMessage.LastOpened == nil {
-				return errors.New("lastOpened field of circuit breaker is nil")
-			}
+	callbackUrlParts := strings.SplitN(subscription.Spec.Subscription.Callback, "url=", 2)
+	callbackUrl := utils.IfThenElse(len(callbackUrlParts) > 1, callbackUrlParts[1], callbackUrlParts[0])
 
-			notifyOpts := options.Notify().
-				SetParameters([]string{label}).
-				SetData(map[string]any{
-					"display": map[string]any{
-						"english": true,
-						"german":  true,
-					},
-					"cb": map[string]any{
-						"environment": cbMessage.Environment,
-						"callbackUrl": callbackUrl,
-						"eventType":   subscription.Spec.Subscription.Type,
-						"lastOpened":  cbMessage.LastOpened.ToTime().Format(time.RFC3339),
-						"loopCounter": cbMessage.LoopCounter,
-						"status":      cbMessage.Status.String(),
-					},
-				}).
-				SetSender(mailConfig.Sender).
-				SetSenderName(mailConfig.SenderName).
-				SetTemplate(template).
-				SetSubject(subject)
+	subject = utils.ReplaceWithMap(subject, map[string]string{
+		"$environment": cbMessage.Environment,
+		"$application": strings.Replace(subscription.Spec.Subscription.SubscriberId, label+"--", "", 1),
+	})
 
-			if err := CurrentSender.SendNotification(context.Background(), notifyOpts); err != nil {
-				return fmt.Errorf("could not send notification for subscription %s: %w", cbMessage.SubscriptionId, err)
-			}
-		}
+	if cbMessage.LastOpened == nil {
+		return errors.New("lastOpened field of circuit breaker is nil")
+	}
+
+	notifyOpts := options.Notify().
+		SetParameters([]string{label}).
+		SetData(map[string]any{
+			"display": map[string]any{
+				"english": true,
+				"german":  true,
+			},
+			"cb": map[string]any{
+				"environment": cbMessage.Environment,
+				"callbackUrl": callbackUrl,
+				"eventType":   subscription.Spec.Subscription.Type,
+				"lastOpened":  cbMessage.LastOpened.ToTime().Format(time.RFC3339),
+				"loopCounter": cbMessage.LoopCounter,
+				"status":      cbMessage.Status.String(),
+			},
+		}).
+		SetSender(mailConfig.Sender).
+		SetSenderName(mailConfig.SenderName).
+		SetTemplate(template).
+		SetSubject(subject)
+
+	if err := CurrentSender.SendNotification(context.Background(), notifyOpts); err != nil {
+		return fmt.Errorf("could not send notification for subscription %s: %w", cbMessage.SubscriptionId, err)
 	}
 
 	return nil

--- a/internal/republish/republish.go
+++ b/internal/republish/republish.go
@@ -173,8 +173,6 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 	log.Info().Msgf("Republishing pending events for subscription %s", subscriptionId)
 
 	picker, err := kafka.NewPicker()
-	// Returning an error results in NOT deleting the republishingEntry from the cache
-	// so that the republishing job will get retried shortly
 	if err != nil {
 		log.Error().Err(err).Fields(map[string]any{
 			"subscriptionId": subscriptionId,
@@ -183,8 +181,6 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 	}
 	defer picker.Close()
 
-	batchSize := config.Current.Republishing.BatchSize
-
 	throttler := createThrottler(
 		subscription.Spec.Subscription.RedeliveriesPerSecond,
 		string(subscription.Spec.Subscription.DeliveryType),
@@ -192,133 +188,205 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 	)
 	defer func() { _ = throttler.Release(context.Background()) }()
 
-	var lastTimestamp any
+	rc := &republishContext{
+		ctx:            ctx,
+		subscription:   subscription,
+		subscriptionId: subscriptionId,
+		republishEntry: republishEntry,
+		picker:         picker,
+		throttler:      throttler,
+		batchSize:      config.Current.Republishing.BatchSize,
+	}
+
+	return rc.processBatches()
+}
+
+// republishContext holds shared state for the republishing loop to avoid excessive parameter passing.
+type republishContext struct {
+	ctx            context.Context
+	subscription   *resource.SubscriptionResource
+	subscriptionId string
+	republishEntry RepublishingCacheEntry
+	picker         kafka.MessagePicker
+	throttler      gohalt.Throttler
+	batchSize      int64
+	lastTimestamp  any
+}
+
+// processBatches iterates over batches of messages until none remain or processing is cancelled.
+func (rc *republishContext) processBatches() error {
 	for {
-		// Per-batch ownership check (fatal: errors preserve cache entry for retry)
-		if cancelled, err := isCancelled(ctx, subscriptionId, true); err != nil {
+		if cancelled, err := isCancelled(rc.ctx, rc.subscriptionId, true); err != nil {
 			return err
 		} else if cancelled {
 			return ErrCancelled
 		}
 
-		var dbMessages []message.StatusMessage
-
-		if republishEntry.OldDeliveryType == "sse" || republishEntry.OldDeliveryType == "server_sent_event" {
-			dbMessages, lastTimestamp, err = mongo.CurrentConnection.FindProcessedMessagesByDeliveryTypeSSE(
-				time.Now(),
-				lastTimestamp,
-				subscriptionId,
-			)
-			if err != nil {
-				log.Error().Err(err).Msgf("Error while fetching PROCESSED messages for subscription %s from db", subscriptionId)
-			}
-			log.Debug().Msgf("Found %d PROCESSED messages in MongoDb", len(dbMessages))
-		} else {
-			dbMessages, lastTimestamp, err = mongo.CurrentConnection.FindWaitingMessages(time.Now(), lastTimestamp, subscriptionId)
-			if err != nil {
-				log.Error().Err(err).Msgf("Error while fetching messages for subscription %s from db", subscriptionId)
-			}
-			log.Debug().Msgf("Found %d WAITING messages in MongoDb", len(dbMessages))
-		}
-
-		log.Debug().Msgf("Last cursor: %v", lastTimestamp)
+		dbMessages, _ := rc.fetchBatch()
 
 		if len(dbMessages) == 0 {
-			break
+			return nil
 		}
 
-		for _, dbMessage := range dbMessages {
-			// Per-message ownership check (non-fatal: log and continue on error)
-			if cancelled, _ := isCancelled(ctx, subscriptionId, false); cancelled {
-				return ErrCancelled
-			}
-
-			for {
-				if acquireResult := throttler.Acquire(context.Background()); acquireResult != nil {
-					sleepInterval := time.Millisecond * 10
-					totalSleepTime := config.Current.Republishing.ThrottlingIntervalTime
-					for slept := time.Duration(0); slept < totalSleepTime; slept += sleepInterval {
-						time.Sleep(sleepInterval)
-					}
-
-					// Post-throttle ownership check (non-fatal: log and continue on error)
-					if cancelled, _ := isCancelled(ctx, subscriptionId, false); cancelled {
-						return ErrCancelled
-					}
-
-					continue
-				}
-				break
-			}
-
-			var newDeliveryType string
-			if !strings.EqualFold(string(subscription.Spec.Subscription.DeliveryType), string(dbMessage.DeliveryType)) {
-				newDeliveryType = strings.ToUpper(string(subscription.Spec.Subscription.DeliveryType))
-			}
-
-			var newCallbackUrl string
-			if subscription.Spec.Subscription.Callback != "" && (subscription.Spec.Subscription.Callback != dbMessage.Properties["callbackUrl"]) {
-				newCallbackUrl = subscription.Spec.Subscription.Callback
-			}
-
-			if dbMessage.Coordinates == nil {
-				log.Error().Msgf("Coordinates in message for subscriptionId %s are nil: %+v", subscriptionId, dbMessage)
-				continue
-			}
-
-			kafkaMessage, err := picker.Pick(&dbMessage)
-			if err != nil {
-				// Returning an error results in NOT deleting the republishingEntry from the cache
-				// so that the republishing job will get retried shortly
-				var nErr *net.OpError
-				if errors.As(err, &nErr) {
-					return err
-				}
-
-				errorList := []error{
-					sarama.ErrEligibleLeadersNotAvailable,
-					sarama.ErrPreferredLeaderNotAvailable,
-					sarama.ErrUnknownLeaderEpoch,
-					sarama.ErrFencedLeaderEpoch,
-					sarama.ErrNotLeaderForPartition,
-					sarama.ErrLeaderNotAvailable,
-				}
-
-				for _, e := range errorList {
-					if errors.Is(err, e) {
-						return err
-					}
-				}
-
-				log.Error().Err(err).Msgf("Error while fetching message from kafka for subscriptionId %s", subscriptionId)
-				continue
-			}
-
-			b3Ctx := tracing.WithB3FromMessage(context.Background(), kafkaMessage)
-			traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
-
-			traceCtx.StartSpan("republish message")
-			traceCtx.SetAttribute("component", "Horizon Golaris")
-			traceCtx.SetAttribute("eventId", dbMessage.Event.Id)
-			traceCtx.SetAttribute("eventType", dbMessage.Event.Type)
-			traceCtx.SetAttribute("subscriptionId", dbMessage.SubscriptionId)
-			traceCtx.SetAttribute("uuid", string(kafkaMessage.Key))
-
-			err = kafka.CurrentHandler.RepublishMessage(traceCtx, kafkaMessage, newDeliveryType, newCallbackUrl, false)
-			if err != nil {
-				log.Warn().Msgf("Error while republishing message for subscriptionId %s: %v", subscriptionId, err)
-				traceCtx.CurrentSpan().RecordError(err)
-			}
-			log.Debug().Msgf("Successfully republished message for subscriptionId %s", subscriptionId)
-
-			traceCtx.EndCurrentSpan()
+		if err := rc.processMessages(dbMessages); err != nil {
+			return err
 		}
 
-		if len(dbMessages) < int(batchSize) {
-			break
+		if len(dbMessages) < int(rc.batchSize) {
+			return nil
+		}
+	}
+}
+
+// fetchBatch retrieves the next batch of messages from MongoDB based on the old delivery type.
+func (rc *republishContext) fetchBatch() ([]message.StatusMessage, error) {
+	if rc.republishEntry.OldDeliveryType == "sse" || rc.republishEntry.OldDeliveryType == "server_sent_event" {
+		dbMessages, lastTimestamp, err := mongo.CurrentConnection.FindProcessedMessagesByDeliveryTypeSSE(
+			time.Now(), rc.lastTimestamp, rc.subscriptionId,
+		)
+		rc.lastTimestamp = lastTimestamp
+		if err != nil {
+			log.Error().Err(err).Msgf("Error while fetching PROCESSED messages for subscription %s from db", rc.subscriptionId)
+		}
+		log.Debug().Msgf("Found %d PROCESSED messages in MongoDb", len(dbMessages))
+		log.Debug().Msgf("Last cursor: %v", rc.lastTimestamp)
+		return dbMessages, err
+	}
+
+	dbMessages, lastTimestamp, err := mongo.CurrentConnection.FindWaitingMessages(
+		time.Now(), rc.lastTimestamp, rc.subscriptionId,
+	)
+	rc.lastTimestamp = lastTimestamp
+	if err != nil {
+		log.Error().Err(err).Msgf("Error while fetching messages for subscription %s from db", rc.subscriptionId)
+	}
+	log.Debug().Msgf("Found %d WAITING messages in MongoDb", len(dbMessages))
+	log.Debug().Msgf("Last cursor: %v", rc.lastTimestamp)
+	return dbMessages, err
+}
+
+// processMessages iterates over a batch and republishes each message.
+func (rc *republishContext) processMessages(dbMessages []message.StatusMessage) error {
+	for _, dbMessage := range dbMessages {
+		if cancelled, _ := isCancelled(rc.ctx, rc.subscriptionId, false); cancelled {
+			return ErrCancelled
+		}
+
+		if err := rc.awaitThrottle(); err != nil {
+			return err
+		}
+
+		if err := rc.republishMessage(dbMessage); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// awaitThrottle blocks until the throttler permits the next message, checking for cancellation.
+func (rc *republishContext) awaitThrottle() error {
+	for {
+		if acquireResult := rc.throttler.Acquire(context.Background()); acquireResult == nil {
+			return nil
+		}
+
+		sleepInterval := time.Millisecond * 10
+		totalSleepTime := config.Current.Republishing.ThrottlingIntervalTime
+		for slept := time.Duration(0); slept < totalSleepTime; slept += sleepInterval {
+			time.Sleep(sleepInterval)
+		}
+
+		if cancelled, _ := isCancelled(rc.ctx, rc.subscriptionId, false); cancelled {
+			return ErrCancelled
+		}
+	}
+}
+
+// republishMessage picks a single message from Kafka and republishes it with tracing.
+func (rc *republishContext) republishMessage(dbMessage message.StatusMessage) error {
+	if dbMessage.Coordinates == nil {
+		log.Error().Msgf("Coordinates in message for subscriptionId %s are nil: %+v", rc.subscriptionId, dbMessage)
+		return nil
+	}
+
+	kafkaMessage, err := rc.picker.Pick(&dbMessage)
+	if err != nil {
+		return rc.handlePickError(err)
+	}
+
+	newDeliveryType := rc.resolveNewDeliveryType(dbMessage)
+	newCallbackUrl := rc.resolveNewCallbackUrl(dbMessage)
+
+	rc.republishWithTracing(kafkaMessage, dbMessage, newDeliveryType, newCallbackUrl)
+	return nil
+}
+
+// handlePickError classifies Kafka pick errors as fatal (returned) or non-fatal (logged, returns nil).
+func (rc *republishContext) handlePickError(err error) error {
+	var nErr *net.OpError
+	if errors.As(err, &nErr) {
+		return err
+	}
+
+	fatalErrors := []error{
+		sarama.ErrEligibleLeadersNotAvailable,
+		sarama.ErrPreferredLeaderNotAvailable,
+		sarama.ErrUnknownLeaderEpoch,
+		sarama.ErrFencedLeaderEpoch,
+		sarama.ErrNotLeaderForPartition,
+		sarama.ErrLeaderNotAvailable,
+	}
+	for _, e := range fatalErrors {
+		if errors.Is(err, e) {
+			return err
+		}
+	}
+
+	log.Error().Err(err).Msgf("Error while fetching message from kafka for subscriptionId %s", rc.subscriptionId)
+	return nil
+}
+
+// resolveNewDeliveryType returns the new delivery type if it differs from the message's current one.
+func (rc *republishContext) resolveNewDeliveryType(dbMessage message.StatusMessage) string {
+	if !strings.EqualFold(string(rc.subscription.Spec.Subscription.DeliveryType), string(dbMessage.DeliveryType)) {
+		return strings.ToUpper(string(rc.subscription.Spec.Subscription.DeliveryType))
+	}
+	return ""
+}
+
+// resolveNewCallbackUrl returns the new callback URL if it differs from the message's current one.
+func (rc *republishContext) resolveNewCallbackUrl(dbMessage message.StatusMessage) string {
+	cb := rc.subscription.Spec.Subscription.Callback
+	if cb != "" && cb != dbMessage.Properties["callbackUrl"] {
+		return cb
+	}
+	return ""
+}
+
+// republishWithTracing creates a tracing span and republishes a Kafka message.
+func (rc *republishContext) republishWithTracing(
+	kafkaMessage *sarama.ConsumerMessage,
+	dbMessage message.StatusMessage,
+	newDeliveryType, newCallbackUrl string,
+) {
+	b3Ctx := tracing.WithB3FromMessage(context.Background(), kafkaMessage)
+	traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
+
+	traceCtx.StartSpan("republish message")
+	traceCtx.SetAttribute("component", "Horizon Golaris")
+	traceCtx.SetAttribute("eventId", dbMessage.Event.Id)
+	traceCtx.SetAttribute("eventType", dbMessage.Event.Type)
+	traceCtx.SetAttribute("subscriptionId", dbMessage.SubscriptionId)
+	traceCtx.SetAttribute("uuid", string(kafkaMessage.Key))
+
+	err := kafka.CurrentHandler.RepublishMessage(traceCtx, kafkaMessage, newDeliveryType, newCallbackUrl, false)
+	if err != nil {
+		log.Warn().Msgf("Error while republishing message for subscriptionId %s: %v", rc.subscriptionId, err)
+		traceCtx.CurrentSpan().RecordError(err)
+	}
+	log.Debug().Msgf("Successfully republished message for subscriptionId %s", rc.subscriptionId)
+
+	traceCtx.EndCurrentSpan()
 }
 
 // ForceDelete attempts to forcefully delete a RepublishingCacheEntry for a given subscriptionId.

--- a/internal/republish/republish.go
+++ b/internal/republish/republish.go
@@ -8,12 +8,6 @@ import (
 	"context"
 	"encoding/gob"
 	"errors"
-	"github.com/1pkg/gohalt"
-	"github.com/IBM/sarama"
-	"github.com/rs/zerolog/log"
-	"github.com/telekom/pubsub-horizon-go/message"
-	"github.com/telekom/pubsub-horizon-go/resource"
-	"github.com/telekom/pubsub-horizon-go/tracing"
 	"net"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
@@ -21,6 +15,13 @@ import (
 	"pubsub-horizon-golaris/internal/mongo"
 	"strings"
 	"time"
+
+	"github.com/1pkg/gohalt"
+	"github.com/IBM/sarama"
+	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/resource"
+	"github.com/telekom/pubsub-horizon-go/tracing"
 )
 
 var ErrCancelled = errors.New("republishing cancelled")
@@ -32,19 +33,25 @@ func init() {
 	gob.Register(RepublishingCacheEntry{})
 }
 
-func createThrottler(redeliveriesPerSecond int, deliveryType string, subscriptionId string) gohalt.Throttler {
+func createThrottler(redeliveriesPerSecond int, deliveryType, subscriptionId string) gohalt.Throttler {
 	if deliveryType == "sse" || deliveryType == "server_sent_event" || redeliveriesPerSecond <= 0 {
-		log.Debug().Msgf("Throttling disabled for subscription %s with delivery type %s and redeliveries per second %d", subscriptionId, deliveryType, redeliveriesPerSecond)
+		log.Debug().
+			Msgf("Throttling disabled for subscription %s with delivery type %s "+
+				"and redeliveries per second %d",
+				subscriptionId, deliveryType, redeliveriesPerSecond)
 		return gohalt.NewThrottlerEcho(nil)
 	}
-	log.Info().Msgf("Throttling enabled for subscription %s with delivery type %s and redeliveries per second %d", subscriptionId, deliveryType, redeliveriesPerSecond)
+	log.Info().
+		Msgf("Throttling enabled for subscription %s with delivery type %s "+
+			"and redeliveries per second %d",
+			subscriptionId, deliveryType, redeliveriesPerSecond)
 	return gohalt.NewThrottlerTimed(uint64(redeliveriesPerSecond), config.Current.Republishing.ThrottlingIntervalTime, 0)
 }
 
 // HandleRepublishingEntry manages the republishing process for a given subscription.
 // The function takes a SubscriptionResource object as a parameter.
 func HandleRepublishingEntry(subscription *resource.SubscriptionResource) {
-	var acquired = false
+	acquired := false
 	ctx := cache.RepublishingCache.NewLockContext(context.Background())
 	subscriptionId := subscription.Spec.Subscription.SubscriptionId
 
@@ -107,7 +114,9 @@ func HandleRepublishingEntry(subscription *resource.SubscriptionResource) {
 		return
 	}
 	if err != nil {
-		log.Error().Err(err).Msgf("Error while republishing pending events for subscriptionId %s. Discarding rebublishing cache entry", subscriptionId)
+		log.Error().
+			Err(err).
+			Msgf("Error while republishing pending events for subscriptionId %s. Discarding rebublishing cache entry", subscriptionId)
 		return
 	}
 
@@ -160,11 +169,10 @@ func isCancelled(ctx context.Context, subscriptionId string, fatal bool) (bool, 
 // RepublishPendingEvents handles the republishing of pending events for a given subscription.
 // The function fetches waiting events from the database and republishes them to Kafka.
 func RepublishPendingEvents(ctx context.Context, subscription *resource.SubscriptionResource, republishEntry RepublishingCacheEntry) error {
-	var subscriptionId = subscription.Spec.Subscription.SubscriptionId
+	subscriptionId := subscription.Spec.Subscription.SubscriptionId
 	log.Info().Msgf("Republishing pending events for subscription %s", subscriptionId)
 
 	picker, err := kafka.NewPicker()
-
 	// Returning an error results in NOT deleting the republishingEntry from the cache
 	// so that the republishing job will get retried shortly
 	if err != nil {
@@ -177,8 +185,12 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 
 	batchSize := config.Current.Republishing.BatchSize
 
-	throttler := createThrottler(subscription.Spec.Subscription.RedeliveriesPerSecond, string(subscription.Spec.Subscription.DeliveryType), subscriptionId)
-	defer throttler.Release(context.Background())
+	throttler := createThrottler(
+		subscription.Spec.Subscription.RedeliveriesPerSecond,
+		string(subscription.Spec.Subscription.DeliveryType),
+		subscriptionId,
+	)
+	defer func() { _ = throttler.Release(context.Background()) }()
 
 	var lastTimestamp any
 	for {
@@ -192,7 +204,11 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 		var dbMessages []message.StatusMessage
 
 		if republishEntry.OldDeliveryType == "sse" || republishEntry.OldDeliveryType == "server_sent_event" {
-			dbMessages, lastTimestamp, err = mongo.CurrentConnection.FindProcessedMessagesByDeliveryTypeSSE(time.Now(), lastTimestamp, subscriptionId)
+			dbMessages, lastTimestamp, err = mongo.CurrentConnection.FindProcessedMessagesByDeliveryTypeSSE(
+				time.Now(),
+				lastTimestamp,
+				subscriptionId,
+			)
 			if err != nil {
 				log.Error().Err(err).Msgf("Error while fetching PROCESSED messages for subscription %s from db", subscriptionId)
 			}
@@ -212,7 +228,6 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 		}
 
 		for _, dbMessage := range dbMessages {
-
 			// Per-message ownership check (non-fatal: log and continue on error)
 			if cancelled, _ := isCancelled(ctx, subscriptionId, false); cancelled {
 				return ErrCancelled
@@ -260,7 +275,7 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 					return err
 				}
 
-				var errorList = []error{
+				errorList := []error{
 					sarama.ErrEligibleLeadersNotAvailable,
 					sarama.ErrPreferredLeaderNotAvailable,
 					sarama.ErrUnknownLeaderEpoch,
@@ -279,8 +294,8 @@ func RepublishPendingEvents(ctx context.Context, subscription *resource.Subscrip
 				continue
 			}
 
-			var b3Ctx = tracing.WithB3FromMessage(context.Background(), kafkaMessage)
-			var traceCtx = tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
+			b3Ctx := tracing.WithB3FromMessage(context.Background(), kafkaMessage)
+			traceCtx := tracing.NewTraceContext(b3Ctx, "golaris", config.Current.Tracing.DebugEnabled)
 
 			traceCtx.StartSpan("republish message")
 			traceCtx.SetAttribute("component", "Horizon Golaris")

--- a/internal/republish/republish_test.go
+++ b/internal/republish/republish_test.go
@@ -6,12 +6,6 @@ package republish
 
 import (
 	"context"
-	"github.com/IBM/sarama"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/telekom/pubsub-horizon-go/enum"
-	"github.com/telekom/pubsub-horizon-go/message"
-	"github.com/telekom/pubsub-horizon-go/resource"
 	"os"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
@@ -20,6 +14,13 @@ import (
 	"pubsub-horizon-golaris/internal/test"
 	"testing"
 	"time"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/telekom/pubsub-horizon-go/enum"
+	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
 func TestMain(m *testing.M) {
@@ -37,10 +38,14 @@ func TestMain(m *testing.M) {
 
 func TestHandleRepublishingEntry_Acquired(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Mock republishPendingEventsFunc
-	republishPendingEventsFunc = func(ctx context.Context, subscription *resource.SubscriptionResource, republishEntry RepublishingCacheEntry) error {
+	republishPendingEventsFunc = func(
+		ctx context.Context,
+		subscription *resource.SubscriptionResource,
+		republishEntry RepublishingCacheEntry,
+	) error {
 		return nil
 	}
 
@@ -69,9 +74,13 @@ func TestHandleRepublishingEntry_Acquired(t *testing.T) {
 
 func TestHandleRepublishingEntry_NotAcquired(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
-	republishPendingEventsFunc = func(ctx context.Context, subscription *resource.SubscriptionResource, republishEntry RepublishingCacheEntry) error {
+	republishPendingEventsFunc = func(
+		ctx context.Context,
+		subscription *resource.SubscriptionResource,
+		republishEntry RepublishingCacheEntry,
+	) error {
 		return nil
 	}
 
@@ -140,7 +149,9 @@ func TestRepublishEvents(t *testing.T) {
 	mockMongo.On("FindWaitingMessages", mock.Anything, mock.Anything, subscriptionId).Return(dbMessages, nil, nil).Once()
 
 	mockPicker.On("Pick", mock.AnythingOfType("*message.StatusMessage")).Return(&kafkaMessage, nil).Twice()
-	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").Return(nil).Twice()
+	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").
+		Return(nil).
+		Twice()
 
 	// Call the function under test
 	subscription := &resource.SubscriptionResource{
@@ -166,7 +177,7 @@ func TestRepublishEvents(t *testing.T) {
 
 func Test_Unlock_RepublishingEntryLocked(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -185,7 +196,7 @@ func Test_Unlock_RepublishingEntryLocked(t *testing.T) {
 
 func Test_Unlock_RepublishingEntryUnlocked(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -203,7 +214,7 @@ func Test_Unlock_RepublishingEntryUnlocked(t *testing.T) {
 
 func Test_ForceDelete_RepublishingEntryLocked(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -222,7 +233,7 @@ func Test_ForceDelete_RepublishingEntryLocked(t *testing.T) {
 
 func Test_ForceDelete_RepublishingEntryUnlocked(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Prepare test data
 	testSubscriptionId := "testSubscriptionId"
@@ -276,7 +287,9 @@ func TestRepublishEventsThrottled(t *testing.T) {
 	mockMongo.On("FindWaitingMessages", mock.Anything, mock.Anything, subscriptionId).Return(dbMessages, nil, nil).Once()
 
 	mockPicker.On("Pick", mock.AnythingOfType("*message.StatusMessage")).Return(&kafkaMessage, nil).Times(len(dbMessages))
-	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").Return(nil).Times(len(dbMessages))
+	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").
+		Return(nil).
+		Times(len(dbMessages))
 
 	// Call the function under test
 	subscription := &resource.SubscriptionResource{
@@ -339,7 +352,9 @@ func TestRepublishEventsUnThrottled(t *testing.T) {
 	mockMongo.On("FindWaitingMessages", mock.Anything, mock.Anything, subscriptionId).Return(dbMessages, nil, nil).Once()
 
 	mockPicker.On("Pick", mock.AnythingOfType("*message.StatusMessage")).Return(&kafkaMessage, nil).Times(len(dbMessages))
-	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").Return(nil).Times(len(dbMessages))
+	mockKafka.On("RepublishMessage", mock.AnythingOfType("*sarama.ConsumerMessage"), "CALLBACK", "http://new-callbackUrl/callback").
+		Return(nil).
+		Times(len(dbMessages))
 
 	// Call the function under test
 	subscription := &resource.SubscriptionResource{
@@ -366,7 +381,7 @@ func TestRepublishEventsUnThrottled(t *testing.T) {
 
 func TestForceDeleteStopsConcurrentGoroutinesViaContainsKey(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	subscriptionId := "test-concurrent-cancel"
 	ctx := context.Background()
@@ -431,7 +446,7 @@ func TestForceDeleteStopsConcurrentGoroutinesViaContainsKey(t *testing.T) {
 
 func TestForceDeleteCancelsViaLockCheck(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	subscriptionId := "test-lock-cancel"
 	ctx := cache.RepublishingCache.NewLockContext(context.Background())

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,22 +6,25 @@ package scheduler
 
 import (
 	"context"
-	"github.com/go-co-op/gocron"
-	"github.com/hazelcast/hazelcast-go-client/predicate"
-	"github.com/rs/zerolog/log"
-	"github.com/telekom/pubsub-horizon-go/enum"
-	"github.com/telekom/pubsub-horizon-go/resource"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/circuitbreaker"
 	"pubsub-horizon-golaris/internal/config"
 	"pubsub-horizon-golaris/internal/handler"
 	"pubsub-horizon-golaris/internal/republish"
 	"time"
+
+	"github.com/go-co-op/gocron"
+	"github.com/hazelcast/hazelcast-go-client/predicate"
+	"github.com/rs/zerolog/log"
+	"github.com/telekom/pubsub-horizon-go/enum"
+	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
-var scheduler *gocron.Scheduler
-var HandleOpenCircuitBreakerFunc = circuitbreaker.HandleOpenCircuitBreaker
-var HandleRepublishingEntryFunc = republish.HandleRepublishingEntry
+var (
+	scheduler                    *gocron.Scheduler
+	HandleOpenCircuitBreakerFunc = circuitbreaker.HandleOpenCircuitBreaker
+	HandleRepublishingEntryFunc  = republish.HandleRepublishingEntry
+)
 
 // StartScheduler initializes and starts the task scheduler. It schedules periodic tasks
 // for checking open circuit breakers and republishing entries based on the configured intervals.
@@ -64,7 +67,9 @@ func StartScheduler() {
 	// Schedule the task for checking messages stuck in state WAITING
 	if waitingHandler := config.Current.Handlers.Waiting; waitingHandler.Enabled {
 		initialDelay := time.Now().Add(waitingHandler.InitialDelay)
-		if _, err := scheduler.Every(waitingHandler.Interval).StartAt(initialDelay).Do(handler.WaitingHandlerService.CheckWaitingEvents); err != nil {
+		if _, err := scheduler.Every(waitingHandler.Interval).
+			StartAt(initialDelay).
+			Do(handler.WaitingHandlerService.CheckWaitingEvents); err != nil {
 			log.Error().Err(err).Msg("Unable to schedule waiting handler task")
 		}
 	}
@@ -87,7 +92,7 @@ func checkOpenCircuitBreakers() {
 		return
 	}
 
-	//Iterate over all circuit breaker entries and handle them
+	// Iterate over all circuit breaker entries and handle them
 	for _, entry := range cbEntries {
 		log.Debug().Msgf("Checking CircuitBreaker with id %s", entry.SubscriptionId)
 
@@ -99,7 +104,7 @@ func checkOpenCircuitBreakers() {
 		} else {
 			log.Debug().Msgf("Subscription with id %s for circuit breaker entry found: %v", entry.SubscriptionId, subscription)
 		}
-		//Handle each circuit breaker entry asynchronously
+		// Handle each circuit breaker entry asynchronously
 		go HandleOpenCircuitBreakerFunc(entry, subscription)
 	}
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -6,10 +6,6 @@ package scheduler
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/telekom/pubsub-horizon-go/enum"
-	"github.com/telekom/pubsub-horizon-go/message"
-	"github.com/telekom/pubsub-horizon-go/resource"
 	"os"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
@@ -18,6 +14,11 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/telekom/pubsub-horizon-go/enum"
+	"github.com/telekom/pubsub-horizon-go/message"
+	"github.com/telekom/pubsub-horizon-go/resource"
 )
 
 func TestMain(m *testing.M) {
@@ -35,7 +36,7 @@ func TestMain(m *testing.M) {
 
 func TestCheckOpenCircuitBreakers_SubscriptionExists(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Mock HandleOpenCircuitBreaker function
 	HandleOpenCircuitBreakerFunc = func(cbMessage message.CircuitBreakerMessage, subscription *resource.SubscriptionResource) {
@@ -67,7 +68,7 @@ func TestCheckOpenCircuitBreakers_SubscriptionExists(t *testing.T) {
 
 func TestCheckOpenCircuitBreakers_NoSubscription(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	// Mock HandleOpenCircuitBreaker function
 	HandleOpenCircuitBreakerFunc = func(cbMessage message.CircuitBreakerMessage, subscription *resource.SubscriptionResource) {}
@@ -89,7 +90,7 @@ func TestCheckOpenCircuitBreakers_NoSubscription(t *testing.T) {
 
 func TestCheckRepublishingEntries_SubscriptionExists(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	ctx := context.Background()
 
@@ -120,7 +121,7 @@ func TestCheckRepublishingEntries_SubscriptionExists(t *testing.T) {
 
 func TestCheckRepublishingEntries_NoSubscription(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	ctx := context.Background()
 
@@ -144,7 +145,7 @@ func TestCheckRepublishingEntries_NoSubscription(t *testing.T) {
 
 func TestCheckOpenCircuitBreakers_ContinuesAfterNilSubscription(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	var mu sync.Mutex
 	handledSubscriptionIds := make([]string, 0)
@@ -207,7 +208,7 @@ func TestCheckOpenCircuitBreakers_ContinuesAfterNilSubscription(t *testing.T) {
 
 func TestCheckRepublishingEntries_ContinuesAfterNilSubscription(t *testing.T) {
 	defer test.ClearCaches()
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	ctx := context.Background()
 
@@ -274,7 +275,7 @@ func TestCheckRepublishingEntries_ContinuesAfterNilSubscription(t *testing.T) {
 }
 
 func TestGetSubscription(t *testing.T) {
-	var assertions = assert.New(t)
+	assertions := assert.New(t)
 
 	mockCache := new(test.SubscriptionMockCache)
 	cache.SubscriptionCache = mockCache

--- a/internal/test/circuitbreaker_mock.go
+++ b/internal/test/circuitbreaker_mock.go
@@ -5,11 +5,8 @@
 package test
 
 import (
-	"encoding/json"
-	"fmt"
 	"github.com/hazelcast/hazelcast-go-client"
 	"github.com/hazelcast/hazelcast-go-client/predicate"
-	"github.com/hazelcast/hazelcast-go-client/serialization"
 	"github.com/stretchr/testify/mock"
 	c "github.com/telekom/pubsub-horizon-go/cache"
 	"github.com/telekom/pubsub-horizon-go/message"
@@ -19,7 +16,7 @@ type CircuitBreakerMockCache struct {
 	mock.Mock
 }
 
-func (m *CircuitBreakerMockCache) Get(mapName string, key string) (*message.CircuitBreakerMessage, error) {
+func (m *CircuitBreakerMockCache) Get(mapName, key string) (*message.CircuitBreakerMessage, error) {
 	args := m.Called(mapName, key)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
@@ -42,12 +39,12 @@ func (m *CircuitBreakerMockCache) GetMap(mapKey string) (*hazelcast.Map, error) 
 	return args.Get(0).(*hazelcast.Map), args.Error(1)
 }
 
-func (m *CircuitBreakerMockCache) Put(cacheName string, key string, value message.CircuitBreakerMessage) error {
+func (m *CircuitBreakerMockCache) Put(cacheName, key string, value message.CircuitBreakerMessage) error {
 	args := m.Called(cacheName, key, value)
 	return args.Error(0)
 }
 
-func (m *CircuitBreakerMockCache) Delete(cacheName string, key string) error {
+func (m *CircuitBreakerMockCache) Delete(cacheName, key string) error {
 	args := m.Called(cacheName, key)
 	return args.Error(0)
 }
@@ -55,12 +52,4 @@ func (m *CircuitBreakerMockCache) Delete(cacheName string, key string) error {
 func (m *CircuitBreakerMockCache) AddListener(mapName string, listener c.Listener[message.CircuitBreakerMessage]) error {
 	args := m.Called(mapName, listener)
 	return args.Error(0)
-}
-
-func (m *CircuitBreakerMockCache) unmarshalHazelcastJson(key any, value any, obj any) error {
-	hzJsonValue, ok := value.(serialization.JSON)
-	if !ok {
-		return fmt.Errorf("value of cached object with key '%s' is not a HazelcastJsonValue", key)
-	}
-	return json.Unmarshal(hzJsonValue, obj)
 }

--- a/internal/test/deliveringhandler_mock.go
+++ b/internal/test/deliveringhandler_mock.go
@@ -8,9 +8,10 @@ package test
 
 import (
 	"context"
+	"time"
+
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 type DeliveringMockHandler struct {
@@ -22,7 +23,7 @@ func (d *DeliveringMockHandler) Get(ctx context.Context, key interface{}) (inter
 	return args.Get(0), args.Error(1)
 }
 
-func (d *DeliveringMockHandler) Set(ctx context.Context, key interface{}, value interface{}) error {
+func (d *DeliveringMockHandler) Set(ctx context.Context, key, value interface{}) error {
 	args := d.Called(ctx, key, value)
 	return args.Error(0)
 }
@@ -37,7 +38,11 @@ func (r *DeliveringMockHandler) TryLockWithLease(ctx context.Context, key interf
 	return args.Bool(0), args.Error(1)
 }
 
-func (d *DeliveringMockHandler) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease time.Duration, timeout time.Duration) (bool, error) {
+func (d *DeliveringMockHandler) TryLockWithLeaseAndTimeout(
+	ctx context.Context,
+	key interface{},
+	lease, timeout time.Duration,
+) (bool, error) {
 	args := d.Called(ctx, key, timeout)
 	return args.Bool(0), args.Error(1)
 }

--- a/internal/test/deliveringhandler_mock.go
+++ b/internal/test/deliveringhandler_mock.go
@@ -4,6 +4,7 @@
 
 //go:build testing
 
+//nolint:dupl // test mock - intentional duplication for type safety
 package test
 
 import (

--- a/internal/test/docker.go
+++ b/internal/test/docker.go
@@ -42,6 +42,7 @@ type Options struct {
 	Hazelcast bool
 }
 
+//nolint:gocognit // Docker setup with sequential container checks
 func SetupDocker(opts *Options) {
 	if alreadySetUp {
 		return

--- a/internal/test/docker.go
+++ b/internal/test/docker.go
@@ -8,8 +8,8 @@ package test
 
 import (
 	"context"
-	"fmt"
 	"log"
+	"net"
 	"time"
 
 	"github.com/hazelcast/hazelcast-go-client"
@@ -79,7 +79,6 @@ func SetupDocker(opts *Options) {
 	pool.MaxWait = 30 * time.Second
 
 	err = pool.Retry(func() error {
-
 		// MongoDB readiness
 		if opts.MongoDb {
 			if err := pingMongoDb(); err != nil {
@@ -114,8 +113,8 @@ func TeardownDocker() {
 }
 
 func pingMongoDb() error {
-	var ctx = context.Background()
-	client, err := mongo.Connect(ctx, options.Client().ApplyURI(fmt.Sprintf("mongodb://%s:%s", mongoHost, mongoPort)))
+	ctx := context.Background()
+	client, err := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://"+net.JoinHostPort(mongoHost, mongoPort)))
 	if err != nil {
 		log.Printf("Could not reach mongodb: %s\n", err)
 		return err
@@ -168,7 +167,7 @@ func setupHazelcast() error {
 }
 
 func pingHazelcast() error {
-	var ctx = context.Background()
+	ctx := context.Background()
 	config := hazelcast.NewConfig()
 
 	config.Cluster.Name = "dev"

--- a/internal/test/failedhandler_mock.go
+++ b/internal/test/failedhandler_mock.go
@@ -8,9 +8,10 @@ package test
 
 import (
 	"context"
+	"time"
+
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 type FailedMockHandler struct {
@@ -22,7 +23,7 @@ func (f *FailedMockHandler) Get(ctx context.Context, key interface{}) (interface
 	return args.Get(0), args.Error(1)
 }
 
-func (f *FailedMockHandler) Set(ctx context.Context, key interface{}, value interface{}) error {
+func (f *FailedMockHandler) Set(ctx context.Context, key, value interface{}) error {
 	args := f.Called(ctx, key, value)
 	return args.Error(0)
 }
@@ -37,7 +38,7 @@ func (r *FailedMockHandler) TryLockWithLease(ctx context.Context, key interface{
 	return args.Bool(0), args.Error(1)
 }
 
-func (d *FailedMockHandler) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease time.Duration, timeout time.Duration) (bool, error) {
+func (d *FailedMockHandler) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease, timeout time.Duration) (bool, error) {
 	args := d.Called(ctx, key, timeout)
 	return args.Bool(0), args.Error(1)
 }

--- a/internal/test/failedhandler_mock.go
+++ b/internal/test/failedhandler_mock.go
@@ -4,6 +4,7 @@
 
 //go:build testing
 
+//nolint:dupl // test mock - intentional duplication for type safety
 package test
 
 import (

--- a/internal/test/handler_cache_mock.go
+++ b/internal/test/handler_cache_mock.go
@@ -8,9 +8,10 @@ package test
 
 import (
 	"context"
+	"time"
+
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 type MockHandlerCache struct {
@@ -22,7 +23,7 @@ func (c *MockHandlerCache) Get(ctx context.Context, key interface{}) (interface{
 	return args.Get(0), args.Error(1)
 }
 
-func (c *MockHandlerCache) Set(ctx context.Context, key interface{}, value interface{}) error {
+func (c *MockHandlerCache) Set(ctx context.Context, key, value interface{}) error {
 	args := c.Called(ctx, key, value)
 	return args.Error(0)
 }
@@ -32,7 +33,7 @@ func (c *MockHandlerCache) TryLockWithTimeout(ctx context.Context, key interface
 	return args.Bool(0), args.Error(1)
 }
 
-func (d *MockHandlerCache) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease time.Duration, timeout time.Duration) (bool, error) {
+func (d *MockHandlerCache) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease, timeout time.Duration) (bool, error) {
 	args := d.Called(ctx, key, lease, timeout)
 	return args.Bool(0), args.Error(1)
 }

--- a/internal/test/health_check_mock.go
+++ b/internal/test/health_check_mock.go
@@ -8,9 +8,10 @@ package test
 
 import (
 	"context"
+	"time"
+
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 type HealthCheckMockMap struct {
@@ -28,61 +29,61 @@ func (h *HealthCheckMockMap) Delete(ctx context.Context, key interface{}) error 
 }
 
 func (h *HealthCheckMockMap) GetEntrySet(ctx context.Context) ([]types.Entry, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) NewLockContext(ctx context.Context) context.Context {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) Unlock(ctx context.Context, key interface{}) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) IsLocked(ctx context.Context, key interface{}) (bool, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) ForceUnlock(ctx context.Context, key interface{}) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
-func (h *HealthCheckMockMap) Set(ctx context.Context, key interface{}, value interface{}) error {
+func (h *HealthCheckMockMap) Set(ctx context.Context, key, value interface{}) error {
 	args := h.Called(ctx, key, value)
 	return args.Error(0)
 }
 
 func (h *HealthCheckMockMap) ContainsKey(ctx context.Context, key interface{}) (bool, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) Clear(ctx context.Context) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) Lock(ctx context.Context, key interface{}) error {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) TryLockWithTimeout(ctx context.Context, key interface{}, timeout time.Duration) (bool, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
 func (h *HealthCheckMockMap) TryLockWithLease(ctx context.Context, key interface{}, lease time.Duration) (bool, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
-func (h *HealthCheckMockMap) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease time.Duration, timeout time.Duration) (bool, error) {
-	//TODO implement me
+func (h *HealthCheckMockMap) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease, timeout time.Duration) (bool, error) {
+	// TODO implement me
 	panic("implement me")
 }

--- a/internal/test/kafkahandler_mock.go
+++ b/internal/test/kafkahandler_mock.go
@@ -10,17 +10,18 @@ import (
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/mock"
 	"github.com/telekom/pubsub-horizon-go/tracing"
-	mongodrv "go.mongodb.org/mongo-driver/mongo"
-	"pubsub-horizon-golaris/internal/config"
 )
 
 type MockKafkaHandler struct {
-	client *mongodrv.Client
-	config *config.Mongo
 	mock.Mock
 }
 
-func (m *MockKafkaHandler) RepublishMessage(traceCtx *tracing.TraceContext, message *sarama.ConsumerMessage, newDeliveryType string, newCallbackUrl string, errorParams bool) error {
+func (m *MockKafkaHandler) RepublishMessage(
+	traceCtx *tracing.TraceContext,
+	message *sarama.ConsumerMessage,
+	newDeliveryType, newCallbackUrl string,
+	errorParams bool,
+) error {
 	args := m.Called(message, newDeliveryType, newCallbackUrl)
 	return args.Error(0)
 }

--- a/internal/test/mongohandler_mock.go
+++ b/internal/test/mongohandler_mock.go
@@ -7,40 +7,51 @@
 package test
 
 import (
+	"time"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/telekom/pubsub-horizon-go/message"
-	mongodrv "go.mongodb.org/mongo-driver/mongo"
-	"pubsub-horizon-golaris/internal/config"
-	"time"
 )
 
 type MockMongoHandler struct {
-	client *mongodrv.Client
-	config *config.Mongo
 	mock.Mock
 }
 
-func (m *MockMongoHandler) FindDistinctSubscriptionsForWaitingEvents(beginTimestamp time.Time, endTimestamp time.Time) ([]string, error) {
+func (m *MockMongoHandler) FindDistinctSubscriptionsForWaitingEvents(beginTimestamp, endTimestamp time.Time) ([]string, error) {
 	args := m.Called(beginTimestamp, endTimestamp)
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *MockMongoHandler) FindWaitingMessages(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
+func (m *MockMongoHandler) FindWaitingMessages(
+	timestamp time.Time,
+	lastTimestamp any,
+	subscriptionId string,
+) ([]message.StatusMessage, any, error) {
 	args := m.Called(timestamp, lastTimestamp, subscriptionId)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }
 
-func (m *MockMongoHandler) FindDeliveringMessagesByDeliveryType(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
+func (m *MockMongoHandler) FindDeliveringMessagesByDeliveryType(
+	timestamp time.Time,
+	lastTimestamp any,
+) ([]message.StatusMessage, any, error) {
 	args := m.Called(timestamp, lastTimestamp)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }
 
-func (m *MockMongoHandler) FindProcessedMessagesByDeliveryTypeSSE(timestamp time.Time, lastTimestamp any, subscriptionId string) ([]message.StatusMessage, any, error) {
+func (m *MockMongoHandler) FindProcessedMessagesByDeliveryTypeSSE(
+	timestamp time.Time,
+	lastTimestamp any,
+	subscriptionId string,
+) ([]message.StatusMessage, any, error) {
 	args := m.Called(timestamp, lastTimestamp, subscriptionId)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }
 
-func (m *MockMongoHandler) FindFailedMessagesWithCallbackUrlNotFoundException(timestamp time.Time, lastTimestamp any) ([]message.StatusMessage, any, error) {
+func (m *MockMongoHandler) FindFailedMessagesWithCallbackUrlNotFoundException(
+	timestamp time.Time,
+	lastTimestamp any,
+) ([]message.StatusMessage, any, error) {
 	args := m.Called(timestamp, lastTimestamp)
 	return args.Get(0).([]message.StatusMessage), args.Get(1), args.Error(2)
 }

--- a/internal/test/picker.go
+++ b/internal/test/picker.go
@@ -7,10 +7,11 @@
 package test
 
 import (
+	"pubsub-horizon-golaris/internal/kafka"
+
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/mock"
 	"github.com/telekom/pubsub-horizon-go/message"
-	"pubsub-horizon-golaris/internal/kafka"
 )
 
 type MockPicker struct {
@@ -22,7 +23,7 @@ func (m *MockPicker) Close() {
 }
 
 func (m *MockPicker) Pick(status *message.StatusMessage) (*sarama.ConsumerMessage, error) {
-	var args = m.Called(status)
+	args := m.Called(status)
 	return args.Get(0).(*sarama.ConsumerMessage), args.Error(1)
 }
 

--- a/internal/test/republishing_mock.go
+++ b/internal/test/republishing_mock.go
@@ -8,9 +8,10 @@ package test
 
 import (
 	"context"
+	"time"
+
 	"github.com/hazelcast/hazelcast-go-client/types"
 	"github.com/stretchr/testify/mock"
-	"time"
 )
 
 type RepublishingMockMap struct {
@@ -22,7 +23,7 @@ func (r *RepublishingMockMap) Get(ctx context.Context, key interface{}) (interfa
 	return args.Get(0), args.Error(1)
 }
 
-func (r *RepublishingMockMap) Set(ctx context.Context, key interface{}, value interface{}) error {
+func (r *RepublishingMockMap) Set(ctx context.Context, key, value interface{}) error {
 	args := r.Called(ctx, key, value)
 	return args.Error(0)
 }
@@ -37,7 +38,7 @@ func (r *RepublishingMockMap) TryLockWithLease(ctx context.Context, key interfac
 	return args.Bool(0), args.Error(1)
 }
 
-func (d *RepublishingMockMap) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease time.Duration, timeout time.Duration) (bool, error) {
+func (d *RepublishingMockMap) TryLockWithLeaseAndTimeout(ctx context.Context, key interface{}, lease, timeout time.Duration) (bool, error) {
 	args := d.Called(ctx, key, timeout)
 	return args.Bool(0), args.Error(1)
 }

--- a/internal/test/subscriptions_mock.go
+++ b/internal/test/subscriptions_mock.go
@@ -33,17 +33,17 @@ func (m *SubscriptionMockCache) AddListener(mapName string, listener c.Listener[
 	return args.Error(0)
 }
 
-func (m *SubscriptionMockCache) Get(cacheName string, key string) (*resource.SubscriptionResource, error) {
+func (m *SubscriptionMockCache) Get(cacheName, key string) (*resource.SubscriptionResource, error) {
 	args := m.Called(cacheName, key)
 	return args.Get(0).(*resource.SubscriptionResource), args.Error(1)
 }
 
-func (m *SubscriptionMockCache) Put(cacheName string, key string, value resource.SubscriptionResource) error {
+func (m *SubscriptionMockCache) Put(cacheName, key string, value resource.SubscriptionResource) error {
 	args := m.Called(cacheName, key, value)
 	return args.Error(0)
 }
 
-func (m *SubscriptionMockCache) Delete(cacheName string, key string) error {
+func (m *SubscriptionMockCache) Delete(cacheName, key string) error {
 	args := m.Called(cacheName, key)
 	return args.Error(0)
 }

--- a/internal/test/testdata.go
+++ b/internal/test/testdata.go
@@ -7,11 +7,12 @@
 package test
 
 import (
+	"time"
+
 	"github.com/telekom/pubsub-horizon-go/enum"
 	"github.com/telekom/pubsub-horizon-go/message"
 	"github.com/telekom/pubsub-horizon-go/resource"
 	"github.com/telekom/pubsub-horizon-go/types"
-	"time"
 )
 
 func NewTestCbMessage(testSubscriptionId string) message.CircuitBreakerMessage {
@@ -25,7 +26,7 @@ func NewTestCbMessage(testSubscriptionId string) message.CircuitBreakerMessage {
 	return testCircuitBreakerMessage
 }
 
-func NewTestSubscriptionResource(testSubscriptionId string, testCallbackUrl string, testEnvironment string) *resource.SubscriptionResource {
+func NewTestSubscriptionResource(testSubscriptionId, testCallbackUrl, testEnvironment string) *resource.SubscriptionResource {
 	testSubscriptionResource := &resource.SubscriptionResource{
 		Spec: struct {
 			Subscription resource.Subscription `json:"subscription"`

--- a/internal/test/utils.go
+++ b/internal/test/utils.go
@@ -8,13 +8,14 @@ package test
 
 import (
 	"context"
-	"github.com/telekom/pubsub-horizon-go/message"
 	"os"
 	"pubsub-horizon-golaris/internal/cache"
 	"pubsub-horizon-golaris/internal/config"
+
+	"github.com/telekom/pubsub-horizon-go/message"
 )
 
-func EnvOrDefault(name string, fallback string) string {
+func EnvOrDefault(name, fallback string) string {
 	value, ok := os.LookupEnv(name)
 	if !ok {
 		return fallback
@@ -48,7 +49,7 @@ func ClearCaches() {
 
 func GenerateStatusMessages(topic string, startPartition int32, startOffset int64, count int) []message.StatusMessage {
 	msgs := make([]message.StatusMessage, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		p := startPartition
 		o := startOffset + int64(i)
 

--- a/internal/test/waitinghandler_mock.go
+++ b/internal/test/waitinghandler_mock.go
@@ -13,7 +13,6 @@ type MockWaitingHandler struct {
 }
 
 func (f *MockWaitingHandler) CheckWaitingEvents() {
-	
 }
 
 func (f *MockWaitingHandler) GetCircuitBreakerSubscriptionsMap() (map[string]struct{}, error) {

--- a/internal/tracing/service.go
+++ b/internal/tracing/service.go
@@ -6,6 +6,9 @@ package tracing
 
 import (
 	"context"
+	"pubsub-horizon-golaris/internal/config"
+	"strings"
+
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/contrib/propagators/b3"
 	"go.opentelemetry.io/otel"
@@ -15,19 +18,20 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
-	"pubsub-horizon-golaris/internal/config"
-	"strings"
 )
 
 func Initialize() {
-	var exporter = createJaegerExporter(config.Current.Tracing.CollectorEndpoint)
+	exporter := createExporter()
 	if exporter != nil {
-		var provider = tracesdk.NewTracerProvider(
+		provider := tracesdk.NewTracerProvider(
 			tracesdk.WithBatcher(exporter),
 			tracesdk.WithResource(
 				resource.NewWithAttributes(
 					semconv.SchemaURL,
-					semconv.ServiceNameKey.String("horizon"))))
+					semconv.ServiceNameKey.String("horizon"),
+				),
+			),
+		)
 
 		otel.SetTracerProvider(provider)
 		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
@@ -38,8 +42,8 @@ func Initialize() {
 	}
 }
 
-func createJaegerExporter(url string) tracesdk.SpanExporter {
-	var options = []otlptracehttp.Option{
+func createExporter() tracesdk.SpanExporter {
+	options := []otlptracehttp.Option{
 		otlptracehttp.WithEndpoint(config.Current.Tracing.CollectorEndpoint),
 	}
 

--- a/internal/utils/comparison.go
+++ b/internal/utils/comparison.go
@@ -4,7 +4,7 @@
 
 package utils
 
-func IfThenElse[T any](condition bool, thenValue T, elseValue T) T {
+func IfThenElse[T any](condition bool, thenValue, elseValue T) T {
 	if condition {
 		return thenValue
 	}


### PR DESCRIPTION
## Summary
- Fix all golangci-lint findings (~180 → 0) against the shared `.golangci.yml` config
- Update `.golangci.yml` formatters: remove conflicting gci/gofmt/goimports, keep gofumpt+golines
- Refactor complex functions to reduce cognitive complexity (republish, failed handler, circuit breaker)
- Extract constants for repeated strings, split long config function, fix correctness issues (bodyclose, noctx, errcheck)

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet -tags testing ./...` passes
- [ ] `golangci-lint run ./...` reports 0 findings
- [ ] `go test -tags testing ./...` passes (requires Docker for Hazelcast/Mongo)
- [ ] CI lint job passes on this branch